### PR TITLE
Add distro detection and configurable browser install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 ## How To Setup Env
-1. Install dependencies:
+1. Install dependencies and clone the repo using the provided setup script:
+    ```bash
+    curl -L https://raw.githubusercontent.com/PcKiLl3r/linux-dev-playbook/master/resources/setup.sh | OS_OVERRIDE=<your_os> bash
     ```
-    sudo pacman -S --needed git ansible
-    ```
+    The `OS_OVERRIDE` environment variable is optional and allows you to force a distribution when autodetection fails.
 2. Make personal dir
     ```
     mkdir personal
@@ -26,8 +27,9 @@
     kinesis_mac: "AA:BB:CC:DD:EE:FF"
     sony_mac: "11:22:33:44:55:66"
     ```
-6. Run Ansible setup script:
-    ```
+6. Edit `config.yml` to customise which browsers are installed or to override OS detection.
+7. Run the playbook manually if desired:
+    ```bash
     ansible-playbook main.yml --vault-password-file vault/vault_pass.txt --ask-become-pass
     ```
 

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,8 @@
+# Default installation configuration
+# Set os_override to force a distribution (e.g. manjaro, fedora, ubuntu)
+os_override: ""
+
+# Browser installation flags
+install_brave: true
+install_firefox: true
+install_chromium: false

--- a/main.yml
+++ b/main.yml
@@ -6,6 +6,7 @@
   vars_files:
     - vault/become_pass.yml
     - vault/bluetooth.yml
+    - config.yml
 
   vars:
     use_on_tv: false
@@ -15,6 +16,14 @@
     - name: Include Vars
       ansible.builtin.include_vars:
         file: ./playbooks/vars.yml
+
+    - name: Determine target operating system
+      ansible.builtin.set_fact:
+        target_os: "{{ os_override | default(ansible_distribution | lower) }}"
+
+    - name: Show detected operating system
+      ansible.builtin.debug:
+        msg: "Installing for OS: {{ target_os }}"
 
     - name: Include Core init tasks
       ansible.builtin.include_tasks:
@@ -46,6 +55,10 @@
     - name: Import Dev-Tools Install
       ansible.builtin.import_tasks:
          file: ./playbooks/dev-tools.yml
+
+    - name: Import Browser Install
+      ansible.builtin.import_tasks:
+         file: ./playbooks/browsers.yml
 
     - name: Import ZShell Install
       ansible.builtin.import_tasks:

--- a/playbooks/browsers.yml
+++ b/playbooks/browsers.yml
@@ -1,0 +1,17 @@
+---
+- name: Install Brave browser
+  import_role:
+    name: staticdev.brave
+  when: install_brave | bool
+
+- name: Install Firefox browser
+  ansible.builtin.package:
+    name: firefox
+    state: present
+  when: install_firefox | bool
+
+- name: Install Chromium browser
+  ansible.builtin.package:
+    name: "{{ 'chromium-browser' if target_os == 'ubuntu' else 'chromium' }}"
+    state: present
+  when: install_chromium | bool

--- a/resources/setup.sh
+++ b/resources/setup.sh
@@ -1,6 +1,33 @@
 #!/usr/bin/env bash
 
-sudo pacman -S --noconfirm ansible git
+if [ -n "$OS_OVERRIDE" ]; then
+  TARGET_OS="$OS_OVERRIDE"
+elif [ -f /etc/manjaro-release ]; then
+  TARGET_OS="manjaro"
+elif [ -f /etc/fedora-release ]; then
+  TARGET_OS="fedora"
+elif [ -f /etc/debian_version ]; then
+  TARGET_OS="debian"
+else
+  TARGET_OS="unknown"
+fi
+
+case "$TARGET_OS" in
+  manjaro)
+    sudo pacman -S --noconfirm ansible git
+    ;;
+  fedora)
+    sudo dnf install -y ansible git
+    ;;
+  debian)
+    sudo apt-get update
+    sudo apt-get install -y ansible git
+    ;;
+  *)
+    echo "Unsupported OS: $TARGET_OS" >&2
+    exit 1
+    ;;
+esac
 git clone https://github.com/PcKiLl3r/linux-dev-playbook ~/personal/linux-dev-playbook
 cd ~/personal/linux-dev-playbook
-ansible-playbook main.yml --vault-password-file ./vault/vault_pass.txt
+ansible-playbook main.yml --vault-password-file ./vault/vault_pass.txt -e os_override=$TARGET_OS


### PR DESCRIPTION
## Summary
- detect OS in the setup script and pass override to ansible
- allow overriding OS and selecting browsers via `config.yml`
- add browser installation tasks
- integrate detection and config into main playbook
- document new workflow in README

## Testing
- `make lint` *(fails: yamllint missing)*

------
https://chatgpt.com/codex/tasks/task_e_688b976ee788833280e3bf1b5bced6e9