### PR TITLE
Add machine preset config override support

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,7 @@
 # Default installation configuration
 # Set os_override to force a distribution (e.g. manjaro, fedora, ubuntu)
 os_override: ""
+machine_preset: ""
 
 # Browser installation flags
 install_brave: true

--- a/main.yml
+++ b/main.yml
@@ -91,3 +91,8 @@
     - name: Import dotfiles setup
       ansible.builtin.import_tasks:
         file: ./playbooks/dotfiles.yml
+
+    - name: Import machine preset overrides
+      ansible.builtin.import_tasks:
+        file: ./playbooks/presets.yml
+

--- a/playbooks/presets.yml
+++ b/playbooks/presets.yml
@@ -1,0 +1,10 @@
+---
+- name: Apply machine specific preset overrides
+  ansible.builtin.copy:
+    src: "resources/presets/{{ machine_preset }}/"
+    dest: "{{ home }}/"
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: preserve
+  when: machine_preset != ""
+

--- a/resources/presets/4k/.config/custom/laptop-buttons.sh
+++ b/resources/presets/4k/.config/custom/laptop-buttons.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+# Custom key bindings for this laptop

--- a/resources/presets/4k/.config/i3/config
+++ b/resources/presets/4k/.config/i3/config
@@ -1,0 +1,2 @@
+# Machine preset for 4K scaling
+exec --no-startup-id xrandr --output eDP1 --scale 0.5x0.5


### PR DESCRIPTION
## Summary
- allow machine-specific config overrides by copying a preset directory
- add variable `machine_preset` to `config.yml`
- include new override tasks after dotfiles
- provide example 4k preset files

## Testing
- `make lint` *(fails: yamllint not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bbfab2e948332a8da4d639858e0e2