### PR TITLE
Add linting setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@
     ansible-playbook main.yml --vault-password-file vault_pass.txt --ask-become-pass
     ```
 
+## Linting and tests
+Run the linting tools before invoking any of the Makefile targets:
+```bash
+make install-lint
+```
+After the tools are installed you can run the usual checks:
+```bash
+make lint
+make test
+```
+
 ## Todo
 Make a script hosted on web to allow usage like:
 ```


### PR DESCRIPTION
## Summary
- document installation of lint tools before running `make lint` or `make test`

## Testing
- `make install-lint`
- `make lint` *(fails: yamllint warnings and errors)*
- `make test` *(fails: yamllint warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bc4b408208332a1de73a52de2a63d