### PR TITLE
Fix inventory config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@
     ```
 5. Run Ansible setup script:
     ```
-    ansible-playbook main.yml --vault-password-file vault_pass.txt --ask-become-pass
-    ```
+ansible-playbook main.yml --vault-password-file vault_pass.txt --ask-become-pass
+```
+
+### Inventory
+This playbook runs against `localhost`, so no inventory file is needed. Ansible uses its default inventory when executing `main.yml`.
 
 ## Todo
 Make a script hosted on web to allow usage like:

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,4 @@
 [defaults]
 allow_world_readable_tmpfiles = true
-INVENTORY = inventory
 pipelining = True
 remote_user = pckill3r


### PR DESCRIPTION
## Summary
- drop unused INVENTORY setting
- clarify that the playbook runs with Ansible's default localhost inventory

## Testing
- `make lint` *(fails: wrong indentation in main.yml)*

------
https://chatgpt.com/codex/tasks/task_e_688bc4f24b0483328b62db06a91d6de4