### PR TITLE
Fix README setup directory and curl path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 2. Make personal dir
     ```
     mkdir personal
-    cd presonal
+    cd personal
     ```
 3. Clone repo:
     ```
@@ -31,5 +31,5 @@ curl https://dev.todo.com | sh
 ```
 mkdir personal
 cd personal
-curl https://raw.githubusercontent.com/PcKiLl3r/linux-dev-playbook/master/resources/setup | sh
+curl https://raw.githubusercontent.com/PcKiLl3r/linux-dev-playbook/master/resources/setup.sh | sh
 ```


### PR DESCRIPTION
## Summary
- fix typo in personal directory instructions
- update setup script path in example curl command

## Testing
- `make lint` *(fails: yamllint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bc5431d00833296ea2bc675ad5a58