### PR TITLE
Add install verification tasks

### DIFF
--- a/playbooks/browsers.yml
+++ b/playbooks/browsers.yml
@@ -4,6 +4,13 @@
     name: staticdev.brave
   when: install_brave | bool
 
+- name: Verify Brave installation
+  ansible.builtin.command: brave-browser --version
+  register: brave_check
+  changed_when: false
+  failed_when: brave_check.rc != 0
+  when: install_brave | bool
+
 - name: Install Firefox browser
   ansible.builtin.package:
     name: firefox

--- a/playbooks/dev-tools.yml
+++ b/playbooks/dev-tools.yml
@@ -7,6 +7,12 @@
       - docker-compose
       - python-pip
 
+- name: Verify Docker installation
+  ansible.builtin.command: docker --version
+  register: docker_check
+  changed_when: false
+  failed_when: docker_check.rc != 0
+
 - name: Ensure Group "docker" Exists with correct gid
   ansible.builtin.group:
     name: docker

--- a/playbooks/neovim.yml
+++ b/playbooks/neovim.yml
@@ -59,6 +59,13 @@
   when: gitclone_result.changed
   become: false
 
+- name: Verify NeoVim installation
+  ansible.builtin.command: nvim --version
+  register: nvim_check
+  changed_when: false
+  failed_when: nvim_check.rc != 0
+  become: false
+
 - name: Install Rust
   ansible.builtin.pacman:
     name:


### PR DESCRIPTION
## Summary
- verify Brave browser installation
- verify Docker installation
- verify NeoVim installation

## Testing
- `make lint` *(fails: wrong indentation etc.)*
- `ansible-playbook --syntax-check main.yml` *(fails: missing vault secrets)*
- `ansible-lint` *(fails: couldn't download Galaxy role)*

------
https://chatgpt.com/codex/tasks/task_e_688bc6b624088332b826be4ff4b24e0f