### PR TITLE
Add Hyprland window manager playbook with optional features

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,16 @@
 # Set os_override to force a distribution (e.g. manjaro, fedora, ubuntu)
 os_override: ""
 machine_preset: ""
+window_manager: i3
+
+# Hyprland optional feature flags
+add_input_group: false
+install_sddm: false
+install_gtk_themes: false
+setup_bluetooth: false
+install_thunar: false
+install_quickshell: false
+install_rog_packages: false
 
 # Browser installation flags
 install_brave: true

--- a/main.yml
+++ b/main.yml
@@ -83,6 +83,12 @@
     - name: Import i3 Install
       ansible.builtin.import_tasks:
         file: ./playbooks/i3.yml
+      when: window_manager == 'i3'
+
+    - name: Import Hyprland Install
+      ansible.builtin.import_tasks:
+        file: ./playbooks/hyprland.yml
+      when: window_manager == 'hyprland'
 
     - name: Import keyboard setup
       ansible.builtin.import_tasks:
@@ -91,6 +97,7 @@
     - name: Import Bluetooth & audio setup
       ansible.builtin.import_tasks:
         file: ./playbooks/bluetooth.yml
+      when: setup_bluetooth | bool and window_manager != 'hyprland'
 
     - name: Import dotfiles setup
       ansible.builtin.import_tasks:

--- a/playbooks/hyprland.yml
+++ b/playbooks/hyprland.yml
@@ -1,0 +1,53 @@
+---
+- name: Install Hyprland packages
+  ansible.builtin.package:
+    name: "{{ hyprland_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"
+
+- name: Add user to input group
+  ansible.builtin.user:
+    name: "{{ username }}"
+    groups: input
+    append: true
+  when: add_input_group | bool
+
+- name: Install SDDM and themes
+  ansible.builtin.package:
+    name: "{{ hyprland_sddm_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"
+  when: install_sddm | bool
+
+- name: Install GTK themes
+  ansible.builtin.package:
+    name: "{{ hyprland_gtk_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"
+  when: install_gtk_themes | bool
+
+- name: Include Bluetooth & audio setup
+  ansible.builtin.import_tasks:
+    file: bluetooth.yml
+  when: setup_bluetooth | bool
+
+- name: Install Thunar file manager
+  ansible.builtin.package:
+    name: "{{ hyprland_thunar_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"
+  when: install_thunar | bool
+
+- name: Install Quickshell
+  ansible.builtin.package:
+    name: "{{ hyprland_quickshell_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"
+  when: install_quickshell | bool
+
+- name: Install ROG-specific packages
+  ansible.builtin.package:
+    name: "{{ hyprland_rog_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"
+  when: install_rog_packages | bool

--- a/playbooks/vars/arch.yml
+++ b/playbooks/vars/arch.yml
@@ -56,6 +56,27 @@ i3_packages:
   - nitrogen
   - conky
 
+hyprland_packages:
+  - hyprland
+  - xdg-desktop-portal-hyprland
+
+hyprland_sddm_packages:
+  - sddm
+
+hyprland_gtk_packages:
+  - gtk-engine-murrine
+
+hyprland_thunar_packages:
+  - thunar
+  - thunar-volman
+
+hyprland_quickshell_packages:
+  - quickshell
+
+hyprland_rog_packages:
+  - asusctl
+  - supergfxctl
+
 tmux_packages:
   - tmux
 

--- a/playbooks/vars/fedora.yml
+++ b/playbooks/vars/fedora.yml
@@ -55,6 +55,27 @@ i3_packages:
   - nitrogen
   - conky
 
+hyprland_packages:
+  - hyprland
+  - xdg-desktop-portal-hyprland
+
+hyprland_sddm_packages:
+  - sddm
+
+hyprland_gtk_packages:
+  - gtk-murrine-engine
+
+hyprland_thunar_packages:
+  - thunar
+  - thunar-volman
+
+hyprland_quickshell_packages:
+  - quickshell
+
+hyprland_rog_packages:
+  - asusctl
+  - supergfxctl
+
 tmux_packages:
   - tmux
 


### PR DESCRIPTION
## Summary
- add hyprland playbook with optional SDDM, GTK, Bluetooth, Thunar, Quickshell and ROG packages
- wire main playbook to run hyprland tasks when selected
- default config disables ROG and cosmetic packages

## Testing
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68938d226f048332bbabb301f28b1a6d