### PR TITLE
docs: add Fedora setup and config template guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@
     curl -L https://raw.githubusercontent.com/PcKiLl3r/linux-dev-playbook/master/resources/setup.sh | OS_OVERRIDE=<your_os> bash
     ```
     The `OS_OVERRIDE` environment variable is optional and allows you to force a distribution when autodetection fails.
+
+### Running on minimal Fedora
+On a minimal Fedora installation, install the required packages first:
+
+```bash
+sudo dnf install -y ansible git
+```
+
+Then clone the repository and run the playbook:
+
+```bash
+git clone https://github.com/PcKiLl3r/linux-dev-playbook
+cd linux-dev-playbook
+cp config.template.yml config.yml
+ansible-playbook main.yml --vault-password-file vault/vault_pass.txt -e os_override=fedora --ask-become-pass
+```
 2. Make personal dir
     ```
     mkdir personal
@@ -33,6 +49,27 @@
     ```bash
     ansible-playbook main.yml --vault-password-file vault/vault_pass.txt --ask-become-pass
     ```
+
+### Configuration
+Copy `config.template.yml` to `config.yml` and adjust values as needed:
+
+```bash
+cp config.template.yml config.yml
+```
+
+Key options available in the configuration file:
+
+- `window_manager`: choose `i3` or `hyprland`. Set to `hyprland` to install the Hyprland compositor.
+- Hyprland extras (effective only when `window_manager` is `hyprland`):
+  - `add_input_group`: add the current user to the `input` group.
+  - `install_sddm`: install the SDDM display manager and themes.
+  - `install_gtk_themes`: install additional GTK themes.
+  - `install_thunar`: install the Thunar file manager.
+  - `install_quickshell`: install the Quickshell Wayland panel.
+  - `install_rog_packages`: install ROG-specific packages.
+- Other flags: `install_bluetooth`, `install_brave`, `install_firefox`, `install_chromium`.
+
+To override automatic package manager detection, set `os_override` in `config.yml` or pass `-e os_override=<distro>` when running `ansible-playbook`.
 
 ### Inventory
 This playbook runs against `localhost`, so no inventory file is needed. Ansible uses its default inventory when executing `main.yml`.

--- a/config.template.yml
+++ b/config.template.yml
@@ -2,7 +2,8 @@
 # Configuration template for linux-dev-playbook
 # Copy this file to config.yml and adjust values as needed.
 
-# Force a specific distribution (e.g., 'manjaro', 'fedora', 'ubuntu').
+# Force a specific distribution (e.g., 'manjaro', 'fedora', 'ubuntu') to
+# override automatic package manager detection.
 # Leave empty to use the detected distribution.
 os_override: ""
 
@@ -11,12 +12,14 @@ os_override: ""
 machine_preset: ""
 
 # Choose which window manager to install: 'i3' or 'hyprland'.
+# Set to 'hyprland' to install the Hyprland compositor and enable the
+# optional Wayland features below.
 window_manager: i3
 
 # Install Bluetooth and audio support.
 install_bluetooth: false
 
-# Hyprland optional feature flags
+# Hyprland optional feature flags (effective only when window_manager is 'hyprland')
 
 # Add the current user to the input group (required for some input devices).
 add_input_group: false

--- a/config.yml
+++ b/config.yml
@@ -2,7 +2,8 @@
 # Example configuration for linux-dev-playbook
 # This file mirrors config.template.yml. Adjust values as needed.
 
-# Force a specific distribution (e.g., 'manjaro', 'fedora', 'ubuntu').
+# Force a specific distribution (e.g., 'manjaro', 'fedora', 'ubuntu') to
+# override automatic package manager detection.
 # Leave empty to use the detected distribution.
 os_override: ""
 
@@ -11,12 +12,14 @@ os_override: ""
 machine_preset: ""
 
 # Choose which window manager to install: 'i3' or 'hyprland'.
+# Set to 'hyprland' to install the Hyprland compositor and enable the
+# optional Wayland features below.
 window_manager: i3
 
 # Install Bluetooth and audio support.
 install_bluetooth: false
 
-# Hyprland optional feature flags
+# Hyprland optional feature flags (effective only when window_manager is 'hyprland')
 
 # Add the current user to the input group (required for some input devices).
 add_input_group: false


### PR DESCRIPTION
## Summary
- document running on minimal Fedora including prerequisites
- explain configuration via `config.template.yml` and override package detection
- describe `window_manager` options and Hyprland extras

## Testing
- `make lint`
- `make test` *(fails: driver docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893935018ec833294c88985c4629c33