### PR TITLE
Add bootstrap script for secret deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ ansible-playbook main.yml --vault-password-file vault/vault_pass.txt -e os_overr
     ansible-playbook main.yml --vault-password-file vault/vault_pass.txt --ask-become-pass
     ```
 
+### Bootstrap script
+Use the helper script to apply secrets and dotfiles:
+```bash
+./scripts/bootstrap.sh
+```
+The script prompts for your Ansible Vault passphrase, runs the playbook, and re-encrypts vault files.
+
 ### Configuration
 Copy `config.template.yml` to `config.yml` and adjust values as needed:
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prompt for vault passphrase
+read -s -p "Enter Ansible Vault passphrase: " VAULT_PASS
+echo
+
+VAULT_FILE=$(mktemp)
+ENCRYPTED_FILES=$(grep -l '^\$ANSIBLE_VAULT' vault/* 2>/dev/null || true)
+DECRYPTED=0
+
+cleanup() {
+  if [ "$DECRYPTED" -eq 1 ] && [ -n "$ENCRYPTED_FILES" ]; then
+    echo "Re-encrypting vault files..."
+    ansible-vault encrypt $ENCRYPTED_FILES --vault-password-file "$VAULT_FILE" >/dev/null 2>&1 || true
+  fi
+  rm -f "$VAULT_FILE"
+}
+trap cleanup EXIT
+
+printf "%s" "$VAULT_PASS" > "$VAULT_FILE"
+
+if [ -n "$ENCRYPTED_FILES" ]; then
+  echo "Decrypting vault files..."
+  if ansible-vault decrypt $ENCRYPTED_FILES --vault-password-file "$VAULT_FILE"; then
+    DECRYPTED=1
+  fi
+fi
+
+# Apply secrets and dotfiles using ansible-playbook
+ansible-playbook main.yml --vault-password-file "$VAULT_FILE"


### PR DESCRIPTION
## Summary
- add helper script to decrypt vault files, run the playbook, and re-encrypt secrets
- document bootstrap script usage in the README

## Testing
- `make install-lint`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_689398783dd4833281ab9f8872d746e6