### PR TITLE
Add Fedora platform to Molecule

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -17,7 +17,7 @@
       become_method: "sudo"
 
     - name: Install dependencies to mirror real environment
-      ansible.builtin.pacman:
+      ansible.builtin.package:
         name:
           - git
         state: present

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,8 +8,16 @@ lint: |
   yamllint .
   ansible-lint
 platforms:
-  - name: instance
+  - name: arch
     image: "geerlingguy/docker-archlinux-ansible:latest"
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+  - name: fedora
+    image: "geerlingguy/docker-fedora-ansible:latest"
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw


### PR DESCRIPTION
## Summary
- add Fedora Docker image alongside Arch in Molecule scenario
- use generic package module in convergence playbook

## Testing
- `make test` *(fails: staticdev.brave was NOT installed successfully: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_6893a7fb5b8c8332b08877e7dc4f0fe0