### PR TITLE
Add host-specific inventory variables

### DIFF
--- a/inventory/host_vars/desktop_nvidia_780ti.yml
+++ b/inventory/host_vars/desktop_nvidia_780ti.yml
@@ -1,0 +1,9 @@
+---
+drivers:
+  - nvidia-driver
+  - nvidia-utils
+power_management:
+  - powertop
+hardware_packages:
+  - nvidia-settings
+  - vulkan-tools

--- a/inventory/host_vars/thinkpad_t16_gen2.yml
+++ b/inventory/host_vars/thinkpad_t16_gen2.yml
@@ -1,0 +1,9 @@
+---
+drivers:
+  - intel-microcode
+power_management:
+  - tlp
+  - powertop
+hardware_packages:
+  - fwupd
+  - thinkfan

--- a/inventory/host_vars/thinkpad_x240.yml
+++ b/inventory/host_vars/thinkpad_x240.yml
@@ -1,0 +1,10 @@
+---
+drivers:
+  - intel-microcode
+power_management:
+  - tlp
+  - powertop
+hardware_packages:
+  - tp-smapi-dkms
+  - acpi-call-dkms
+  - hdapsd

--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -1,0 +1,9 @@
+---
+all:
+  hosts:
+    thinkpad_t16_gen2:
+      ansible_host: thinkpad_t16_gen2
+    thinkpad_x240:
+      ansible_host: thinkpad_x240
+    desktop_nvidia_780ti:
+      ansible_host: desktop_nvidia_780ti


### PR DESCRIPTION
## Summary
- add inventory file enumerating ThinkPad T16 Gen2, ThinkPad X240, and desktop with Nvidia 780 Ti
- define host-specific driver, power management, and hardware package variables

## Testing
- `pre-commit run --files inventory/hosts.yml inventory/host_vars/thinkpad_t16_gen2.yml inventory/host_vars/thinkpad_x240.yml inventory/host_vars/desktop_nvidia_780ti.yml`


------
https://chatgpt.com/codex/tasks/task_e_6893a82265d083329f1705da2907f6a5