### PR TITLE
Add optional multimedia codec installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Key options available in the configuration file:
   - `install_thunar`: install the Thunar file manager.
   - `install_quickshell`: install the Quickshell Wayland panel.
   - `install_rog_packages`: install ROG-specific packages.
-- Other flags: `install_bluetooth`, `install_brave`, `install_firefox`, `install_chromium`.
+- Other flags: `install_bluetooth`, `install_codecs`, `install_brave`, `install_firefox`, `install_chromium`.
 
 To override automatic package manager detection, set `os_override` in `config.yml` or pass `-e os_override=<distro>` when running `ansible-playbook`.
 

--- a/config.template.yml
+++ b/config.template.yml
@@ -19,6 +19,9 @@ window_manager: i3
 # Install Bluetooth and audio support.
 install_bluetooth: false
 
+# Install multimedia codecs like ffmpeg and gstreamer.
+install_codecs: false
+
 # Hyprland optional feature flags (effective only when window_manager is 'hyprland')
 
 # Add the current user to the input group (required for some input devices).

--- a/config.yml
+++ b/config.yml
@@ -19,6 +19,9 @@ window_manager: i3
 # Install Bluetooth and audio support.
 install_bluetooth: false
 
+# Install multimedia codecs like ffmpeg and gstreamer.
+install_codecs: false
+
 # Hyprland optional feature flags (effective only when window_manager is 'hyprland')
 
 # Add the current user to the input group (required for some input devices).

--- a/main.yml
+++ b/main.yml
@@ -64,6 +64,11 @@
       ansible.builtin.import_tasks:
         file: ./playbooks/browsers.yml
 
+    - name: Import Codecs Install
+      ansible.builtin.import_tasks:
+        file: ./playbooks/codecs.yml
+      when: install_codecs | bool
+
     - name: Import ZShell Install
       ansible.builtin.import_tasks:
         file: ./playbooks/zsh.yml

--- a/playbooks/codecs.yml
+++ b/playbooks/codecs.yml
@@ -1,0 +1,6 @@
+---
+- name: Install multimedia codecs
+  ansible.builtin.package:
+    name: "{{ codecs_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/playbooks/vars/arch.yml
+++ b/playbooks/vars/arch.yml
@@ -21,6 +21,15 @@ mobile_dev_packages:
 game_dev_packages:
   - godot
 
+codecs_packages:
+  - ffmpeg
+  - gstreamer
+  - gst-libav
+  - gst-plugins-base
+  - gst-plugins-good
+  - gst-plugins-bad
+  - gst-plugins-ugly
+
 utils_packages:
   - fzf
   - ripgrep

--- a/playbooks/vars/fedora.yml
+++ b/playbooks/vars/fedora.yml
@@ -20,6 +20,14 @@ mobile_dev_packages:
 game_dev_packages:
   - godot
 
+codecs_packages:
+  - ffmpeg
+  - gstreamer1-plugins-base
+  - gstreamer1-plugins-good
+  - gstreamer1-plugins-bad-free
+  - gstreamer1-plugins-ugly
+  - gstreamer1-libav
+
 utils_packages:
   - fzf
   - ripgrep


### PR DESCRIPTION
## Summary
- add `install_codecs` flag to install multimedia codecs
- support ffmpeg and gstreamer packages for Arch and Fedora
- document new option in configuration guide

## Testing
- `python3 -m pre_commit run --files README.md config.template.yml config.yml main.yml playbooks/vars/arch.yml playbooks/vars/fedora.yml playbooks/codecs.yml`
- `make lint`
- `make test` *(fails: `molecule: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6893a82a4d448332ac1573975e62b0a1