### PR TITLE
Ensure Molecule test dependencies are installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PYTHON = python3
 MOLECULE = molecule
 ANSIBLE_PLAYBOOK = ansible-playbook
 LINT_TOOLS = yamllint ansible-lint
+TEST_DEPS = molecule molecule-plugins[docker] yamllint ansible-lint
 
 # Default target
 .DEFAULT_GOAL := help
@@ -24,6 +25,10 @@ install-lint:
 	@echo "Installing linting tools..."
 	$(PIP) install $(LINT_TOOLS)
 
+# Install Molecule and other testing tools
+install-test-tools:
+	$(PIP) install --user $(TEST_DEPS)
+
 # Run linters and syntax checks in the specified order
 lint:
 	@echo "Running yamllint..."
@@ -35,13 +40,13 @@ lint:
 #	ansible-lint
 	@echo "Skipping ansible-lint due to environment limitations..."
 
-# Run Molecule tests, always running lint first
-test: lint
+# Run Molecule tests, ensuring dependencies are installed and linting runs first
+test: install-test-tools lint
 	@echo "Running Molecule tests..."
 	$(MOLECULE) test
 
-# Run Molecule converge, always running lint first
-converge: lint
+# Run Molecule converge, ensuring dependencies are installed and linting runs first
+converge: install-test-tools lint
 	@echo "Running Molecule converge..."
 	$(MOLECULE) converge
 


### PR DESCRIPTION
## Summary
- add `TEST_DEPS` variable listing Molecule and linting tools
- introduce `install-test-tools` target to install testing dependencies
- run `install-test-tools` before `make test` and `make converge`

## Testing
- `make test` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_6898593c2e6883329727aa03010937b0