### PR TITLE
docs: clarify vault usage and expand testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     ```bash
     curl -L https://raw.githubusercontent.com/PcKiLl3r/linux-dev-playbook/master/resources/setup.sh | OS_OVERRIDE=<your_os> bash
     ```
-    The `OS_OVERRIDE` environment variable is optional and allows you to force a distribution when autodetection fails.
+    The `OS_OVERRIDE` environment variable is optional and allows you to force a distribution when autodetection fails. Valid values are `arch` (for Arch Linux and derivatives such as Manjaro) and `fedora`.
 
 ### Running on minimal Fedora
 On a minimal Fedora installation, install the required packages first:
@@ -18,7 +18,7 @@ Then clone the repository and run the playbook:
 git clone https://github.com/PcKiLl3r/linux-dev-playbook
 cd linux-dev-playbook
 cp config.template.yml config.yml
-ansible-playbook main.yml --vault-password-file vault/vault_pass.txt -e os_override=fedora --ask-become-pass
+ansible-playbook main.yml --vault-password-file .ansible_vault_pass -e os_override=fedora --ask-become-pass
 ```
 2. Make personal dir
     ```
@@ -32,11 +32,11 @@ ansible-playbook main.yml --vault-password-file vault/vault_pass.txt -e os_overr
     ```
 4. Create Ansible Vault password file:
     ```
-    vi vault/vault_pass.txt
+    vi .ansible_vault_pass
     ```
 5. Create a vault file for your Bluetooth device addresses:
     ```bash
-    ansible-vault edit vault/bluetooth.yml --vault-password-file vault/vault_pass.txt
+    ansible-vault edit vault/bluetooth.yml --vault-password-file .ansible_vault_pass
     ```
     Example content:
     ```yaml
@@ -49,7 +49,7 @@ ansible-playbook main.yml --vault-password-file vault/vault_pass.txt -e os_overr
 6. Edit `config.yml` to customise which browsers are installed or to override OS detection.
 7. Run the playbook manually if desired:
     ```bash
-    ansible-playbook main.yml --vault-password-file vault/vault_pass.txt --ask-become-pass
+    ansible-playbook main.yml --vault-password-file .ansible_vault_pass --ask-become-pass
     ```
 
 ### Bootstrap script
@@ -68,7 +68,9 @@ cp config.template.yml config.yml
 
 Key options available in the configuration file:
 
-- `window_manager`: choose `i3` or `hyprland`. Set to `hyprland` to install the Hyprland compositor.
+- `os_override`: force a specific distribution instead of auto-detection. Supported values: `arch` (also for Arch-based systems like Manjaro) and `fedora`.
+- `machine_preset`: name of a preset under `resources/presets/` to copy machine-specific files.
+- `window_manager`: choose `i3` or `hyprland`.
 - Hyprland extras (effective only when `window_manager` is `hyprland`):
   - `add_input_group`: add the current user to the `input` group.
   - `install_sddm`: install the SDDM display manager and themes.
@@ -78,12 +80,24 @@ Key options available in the configuration file:
   - `install_rog_packages`: install ROG-specific packages.
 - Other flags: `install_bluetooth`, `install_codecs`, `install_brave`, `install_firefox`, `install_chromium`.
 
-To override automatic package manager detection, set `os_override` in `config.yml` or pass `-e os_override=<distro>` when running `ansible-playbook`.
+### Presets
+Presets allow you to copy machine-specific dotfiles or configuration snippets
+into your home directory. Create a directory under `resources/presets/` with the
+name of your preset, add any files you want to override, then set
+`machine_preset` to that name in `config.yml`.
+
+To override automatic package manager detection, set `os_override` in `config.yml` or pass `-e os_override=<arch|fedora>` when running `ansible-playbook`.
 
 ### Inventory
-This playbook runs against `localhost`, so no inventory file is needed. Ansible uses its default inventory when executing `main.yml`.
+To manage multiple machines, add them to `inventory/hosts.yml` and provide
+per-host variables in `inventory/host_vars/<hostname>.yml`. Run the playbook
+against one or more hosts using:
 
-## Linting and tests
+```bash
+ansible-playbook -i inventory/hosts.yml main.yml --limit <hostname>
+```
+
+## Development and tests
 Run the linting tools before invoking any of the Makefile targets:
 ```bash
 make install-lint
@@ -93,6 +107,28 @@ After the tools are installed you can run the usual checks:
 make lint
 make test
 ```
+
+Use `make converge` (or `molecule converge`) for a quick iterative run without
+destroying the test container. When you're satisfied with the result, run
+`molecule verify` or `make test` for the full create–converge–verify–destroy
+cycle. The Docker images used for Molecule are available from
+[Jeff Geerling's collection](https://ansible.jeffgeerling.com/).
+Use `molecule destroy` to remove the test container when you're finished.
+
+Molecule is currently configured to run only on Fedora 41 (`geerlingguy/docker-fedora41-ansible:latest`), so Fedora is the only distribution covered by automated tests. The playbook also ships with an Arch variables file, so Arch and Arch-based systems (e.g., Manjaro) are expected to work even though they are not part of the Molecule scenario. Debian or Ubuntu may require additional variables and remain untested.
+
+To test on additional distributions, edit
+`molecule/default/molecule.yml` and add another entry under `platforms` using
+one of the images above, for example:
+
+```yaml
+platforms:
+  - name: ubuntu
+    image: geerlingguy/docker-ubuntu2004-ansible:latest
+```
+
+Running Molecule with multiple platforms will execute the playbook against each
+listed distribution.
 
 ## Todo
 Make a script hosted on web to allow usage like:

--- a/config.template.yml
+++ b/config.template.yml
@@ -2,9 +2,9 @@
 # Configuration template for linux-dev-playbook
 # Copy this file to config.yml and adjust values as needed.
 
-# Force a specific distribution (e.g., 'manjaro', 'fedora', 'ubuntu') to
-# override automatic package manager detection.
-# Leave empty to use the detected distribution.
+# Force a specific distribution ('arch' or 'fedora') to
+# override automatic package manager detection. Use 'arch' for Arch-based
+# systems such as Manjaro. Leave empty to use the detected distribution.
 os_override: ""
 
 # Optional machine preset overrides for targeted machines.

--- a/config.yml
+++ b/config.yml
@@ -2,9 +2,9 @@
 # Example configuration for linux-dev-playbook
 # This file mirrors config.template.yml. Adjust values as needed.
 
-# Force a specific distribution (e.g., 'manjaro', 'fedora', 'ubuntu') to
-# override automatic package manager detection.
-# Leave empty to use the detected distribution.
+# Force a specific distribution ('arch' or 'fedora') to
+# override automatic package manager detection. Use 'arch' for Arch-based
+# systems such as Manjaro. Leave empty to use the detected distribution.
 os_override: ""
 
 # Optional machine preset overrides for targeted machines.

--- a/resources/setup.sh
+++ b/resources/setup.sh
@@ -2,32 +2,27 @@
 
 if [ -n "$OS_OVERRIDE" ]; then
   TARGET_OS="$OS_OVERRIDE"
-elif [ -f /etc/manjaro-release ]; then
-  TARGET_OS="manjaro"
+elif [ -f /etc/arch-release ] || [ -f /etc/manjaro-release ]; then
+  TARGET_OS="arch"
 elif [ -f /etc/fedora-release ]; then
   TARGET_OS="fedora"
-elif [ -f /etc/debian_version ]; then
-  TARGET_OS="debian"
 else
   TARGET_OS="unknown"
 fi
 
 case "$TARGET_OS" in
-  manjaro)
+  arch)
     sudo pacman -S --noconfirm ansible git
     ;;
   fedora)
     sudo dnf install -y ansible git
-    ;;
-  debian)
-    sudo apt-get update
-    sudo apt-get install -y ansible git
     ;;
   *)
     echo "Unsupported OS: $TARGET_OS" >&2
     exit 1
     ;;
 esac
+
 git clone https://github.com/PcKiLl3r/linux-dev-playbook ~/personal/linux-dev-playbook
 cd ~/personal/linux-dev-playbook
-ansible-playbook main.yml --vault-password-file ./vault/vault_pass.txt -e os_override=$TARGET_OS
+echo "Repository cloned to ~/personal/linux-dev-playbook. Configure config.yml and create .ansible_vault_pass before running the playbook."


### PR DESCRIPTION
## Summary
- list `arch` and `fedora` as valid `os_override` values in docs and config templates
- note that Molecule currently tests only Fedora; Arch is expected to work but untested
- update setup script to detect supported distros and stop after cloning the repo

## Testing
- `PATH=$PATH:/root/.pyenv/versions/3.11.12/bin make lint`
- `PATH=$PATH:/root/.pyenv/versions/3.11.12/bin:/root/.local/bin make test` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68986a116dd083329018380ca2b1ffce