### PR TITLE
Expose common tasks via Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-
 # Variables
 PYTHON = python3
 PIP = $(PYTHON) -m pip
 MOLECULE = molecule
 ANSIBLE_PLAYBOOK = ansible-playbook
+ANSIBLE_GALAXY = ansible-galaxy
 LINT_TOOLS = yamllint ansible-lint
+VAULT_PASSWORD_FILE ?= vault/vault_pass.txt
 
 # Default target
 .DEFAULT_GOAL := help
@@ -15,7 +16,10 @@ help:
 	@echo "  make lint            - Run all linters and syntax checks (yamllint, ansible-playbook syntax check, ansible-lint)"
 	@echo "  make test            - Run linting and Molecule tests"
 	@echo "  make converge        - Run linting and Molecule converge"
+	@echo "  make run             - Execute the main Ansible playbook"
+	@echo "  make install         - Install lint tools and Ansible requirements"
 	@echo "  make install-lint    - Install all linting tools"
+	@echo "  make install-requirements - Install Ansible roles and collections"
 	@echo "  make clean           - Clean up temporary files"
 	@echo "  make all             - Run linting, syntax checks, and Molecule tests"
 
@@ -23,6 +27,14 @@ help:
 install-lint:
 	@echo "Installing linting tools..."
 	$(PIP) install $(LINT_TOOLS)
+
+# Install Ansible roles and collections
+install-requirements:
+	@echo "Installing Ansible roles and collections..."
+	$(ANSIBLE_GALAXY) install -r requirements.yml
+
+# Install lint tools and Ansible requirements
+install: install-lint install-requirements
 
 # Run linters and syntax checks in the specified order
 lint:
@@ -32,6 +44,11 @@ lint:
 	$(ANSIBLE_PLAYBOOK) --syntax-check main.yml
 	@echo "Running ansible-lint..."
 	ansible-lint
+
+# Execute the main playbook
+run:
+	@echo "Running main playbook..."
+	$(ANSIBLE_PLAYBOOK) main.yml --vault-password-file $(VAULT_PASSWORD_FILE) --ask-become-pass
 
 # Run Molecule tests, always running lint first
 test: lint

--- a/README.md
+++ b/README.md
@@ -19,22 +19,36 @@
     ```
 5. Run Ansible setup script:
     ```
-ansible-playbook main.yml --vault-password-file vault_pass.txt --ask-become-pass
-```
+    make run
+    ```
 
 ### Inventory
 This playbook runs against `localhost`, so no inventory file is needed. Ansible uses its default inventory when executing `main.yml`.
 
 ## Linting and tests
-Run the linting tools before invoking any of the Makefile targets:
+Run the linting tools and install role requirements before invoking any of the Makefile targets:
 ```bash
-make install-lint
+make install
 ```
-After the tools are installed you can run the usual checks:
+After the dependencies are installed you can run the usual checks:
 ```bash
 make lint
 make test
 ```
+
+### Makefile commands
+The Makefile exposes several common development tasks:
+
+- `make run` – Execute the main Ansible playbook (uses `vault/vault_pass.txt` by default)
+- `make lint` – Run yamllint, ansible-playbook syntax check, and ansible-lint
+- `make test` – Run linting and Molecule tests
+- `make converge` – Run linting and Molecule converge
+- `make install` – Install lint tools and Ansible requirements
+- `make install-lint` – Install all linting tools
+- `make install-requirements` – Install Ansible roles and collections
+- `make clean` – Clean up temporary files
+- `make all` – Run linting, syntax checks, and Molecule tests
+- `make help` – List available commands
 
 ## Todo
 Make a script hosted on web to allow usage like:


### PR DESCRIPTION
## Summary
- add common run and install tasks to Makefile
- document Makefile commands in the README

## Testing
- `PATH=/root/.pyenv/versions/3.11.12/bin:$PATH make lint` *(fails: wrong indentation and line length in YAML files)*
- `PATH=/root/.pyenv/versions/3.11.12/bin:$PATH make test` *(fails: same yamllint errors as above)*

------
https://chatgpt.com/codex/tasks/task_e_6898d54fbbec8332bd8f457b3c2be701