### PR TITLE
Fix Molecule image env variable evaluation

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,8 +8,8 @@ lint: |
   yamllint .
   ansible-lint
 platforms:
-  - name: "{{ lookup('env', 'MOLECULE_DISTRO') | default('fedora') }}"
-    image: "{{ lookup('env', 'MOLECULE_IMAGE') | default('geerlingguy/docker-fedora41-ansible:latest') }}"
+  - name: "${MOLECULE_DISTRO:-fedora}"
+    image: "${MOLECULE_IMAGE:-geerlingguy/docker-fedora41-ansible:latest}"
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw


### PR DESCRIPTION
## Summary
- use shell-style env vars in Molecule config for platform name and image

## Testing
- `MOLECULE_MACHINE_PRESET=thinkpad_t16_gen2 ANSIBLE_VAULT_PASSWORD_FILE=../../.ansible_vault_pass make test` *(fails: Unknown error when attempting to call Galaxy)*

------
https://chatgpt.com/codex/tasks/task_e_689b58c412a8833286157898d8a17a78