### PR TITLE
Fix machine preset task for Molecule tests

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -40,6 +40,8 @@
         path: "{{ playbook_dir }}/../../config.yml"
         regexp: '^machine_preset:'
         line: "machine_preset: \"{{ lookup('ansible.builtin.env', 'MOLECULE_MACHINE_PRESET') }}\""
+      delegate_to: localhost
+      run_once: true
       when: lookup('ansible.builtin.env', 'MOLECULE_MACHINE_PRESET') | length > 0
 
 - name: Import Main Playbook


### PR DESCRIPTION
## Summary
- delegate machine preset task to localhost to ensure config is updated

## Testing
- `pre-commit run --files molecule/default/converge.yml`
- `MOLECULE_MACHINE_PRESET=thinkpad_t16_gen2 ANSIBLE_VAULT_PASSWORD_FILE=../../.ansible_vault_pass make test` *(failed: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_689b5c06cd8883329c91105440e6e6cf