### PR TITLE
Handle empty os_override value

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -19,7 +19,7 @@
 
     - name: Determine target operating system
       ansible.builtin.set_fact:
-        target_os: "{{ os_override | default(ansible_distribution | lower) }}"
+        target_os: "{{ os_override | default(ansible_distribution | lower, true) }}"
 
     - name: Include distro vars
       ansible.builtin.include_vars:


### PR DESCRIPTION
## Summary
- avoid passing an empty os_override to distro vars selection

## Testing
- `yamllint .`
- `pre-commit run --files main.yml`
- `MOLECULE_MACHINE_PRESET=thinkpad_t16_gen2 make test` *(fails: Unknown error when calling Galaxy - staticdev.brave)*

------
https://chatgpt.com/codex/tasks/task_e_689b5eecb1548332a8dbe4366ae96abc