### PR TITLE
Skip Brave role on non-Debian systems

### DIFF
--- a/playbooks/browsers.yml
+++ b/playbooks/browsers.yml
@@ -2,14 +2,14 @@
 - name: Install Brave browser
   import_role:
     name: staticdev.brave
-  when: install_brave | bool
+  when: install_brave | bool and target_os in ['debian', 'ubuntu']
 
 - name: Verify Brave installation
   ansible.builtin.command: brave-browser --version
   register: brave_check
   changed_when: false
   failed_when: brave_check.rc != 0
-  when: install_brave | bool
+  when: install_brave | bool and target_os in ['debian', 'ubuntu']
 
 - name: Install Firefox browser
   ansible.builtin.package:

--- a/playbooks/gui-software.yml
+++ b/playbooks/gui-software.yml
@@ -49,6 +49,7 @@
 - name: Import install Brave browser role
   import_role:
     name: staticdev.brave
+  when: install_brave | bool and target_os in ['debian', 'ubuntu']
 
 - name: Install Blender
   ansible.builtin.package:


### PR DESCRIPTION
## Summary
- guard Brave browser role against non-Debian OSes

## Testing
- `MOLECULE_MACHINE_PRESET=thinkpad_t16_gen2 make test` *(fails: ansible-galaxy 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b6238e5948332af8bb6b0d76b605d