### PR TITLE
chore: skip galaxy roles in yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -18,3 +18,4 @@ rules:
     max: 1
 ignore: |
   vault/*
+  .ansible/**


### PR DESCRIPTION
## Summary
- ignore `.ansible` directory in yamllint so vendored roles do not trigger lint failures

## Testing
- `yamllint .`
- `MOLECULE_MACHINE_PRESET=thinkpad_t16_gen2 make test` *(fails: staticdev.brave role not installed: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b6b8165308332a3c1a3085f34b969