### PR TITLE
Fix ansible-lint tasks configuration and adjust i3 playbook

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,7 +2,7 @@
 exclude_paths:
   - molecule/
 kinds:
-  - playbooks/vars.yml: vars
-  - playbooks/vars/*.yml: vars
-  - playbooks/*.yml: tasks
+  - vars: playbooks/vars.yml
+  - vars: playbooks/vars/*.yml
+  - tasks: playbooks/*.yml
 parseable: true

--- a/playbooks/i3.yml
+++ b/playbooks/i3.yml
@@ -1,5 +1,5 @@
 ---
-- name:
+- name: Install i3 packages
   ansible.builtin.package:
     name: "{{ i3_packages }}"
     state: present


### PR DESCRIPTION
## Summary
- configure ansible-lint to treat playbooks directory as task files
- give i3 task a proper name and remove unused machine learning placeholder

## Testing
- `yamllint .`
- `ansible-lint` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_689b6ccdcdf48332aec62607e41b3852