### PR TITLE
Align ansible configuration with current ansible-core expectations

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,4 +5,6 @@ kinds:
   - vars: playbooks/vars.yml
   - vars: playbooks/vars/*.yml
   - tasks: playbooks/*.yml
+  - tasks: '!playbooks/vars.yml'
+  - tasks: '!playbooks/vars/*.yml'
 parseable: true

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,5 +3,5 @@ allow_world_readable_tmpfiles = true
 pipelining = True
 remote_user = pckill3r
 vault_password_file = .ansible_vault_pass
-collections_paths = ./collections
+collections_path = ./collections
 remote_tmp = /tmp/.ansible-${USER}


### PR DESCRIPTION
## Summary
- use `collections_path` instead of deprecated `collections_paths`
- classify playbook files in `.ansible-lint` so task and vars files are parsed correctly

## Testing
- `ansible-lint --offline` *(fails: internal-error: ansible-playbook --syntax-check returned 1 for multiple playbooks)*

------
https://chatgpt.com/codex/tasks/task_e_689b6ebc83b08332925b7caff551d699