### PR TITLE
Use master branch when cloning repositories

### DIFF
--- a/tasks/core.yml
+++ b/tasks/core.yml
@@ -16,7 +16,7 @@
   ansible.builtin.git:
     repo: https://github.com/PcKiLl3r/linux-dev-playbook.git
     dest: ~/personal/linux-dev-playbook
-    version: main
+    version: master
   become_user: "{{ username }}"
   become: true
 

--- a/tasks/dotfiles.yml
+++ b/tasks/dotfiles.yml
@@ -10,7 +10,7 @@
   ansible.builtin.git:
     repo: https://github.com/PcKiLl3r/.dotfiles.git
     dest: ~/.dotfiles
-    version: main
+    version: master
   become: true
   become_user: "{{ username }}"
 


### PR DESCRIPTION
## Summary
- clone linux-dev-playbook and dotfiles repos from their `master` branches to match actual repository layout

## Testing
- `MOLECULE_MACHINE_PRESET=thinkpad_t16_gen2 make test` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_689b79c311e08332a8b89ab2a40efb31