### PR TITLE
Install LuaCheck locally

### DIFF
--- a/tasks/neovim.yml
+++ b/tasks/neovim.yml
@@ -83,7 +83,9 @@
     use: "{{ pkg_mgr }}"
 
 - name: Install LuaCheck
-  ansible.builtin.command: luarocks install luacheck
+  ansible.builtin.command: luarocks --local install luacheck
+  args:
+    creates: "{{ home }}/.luarocks/bin/luacheck"
   changed_when: false
   become: true
   become_user: "{{ username }}"


### PR DESCRIPTION
## Summary
- install LuaCheck via luarocks in user space

## Testing
- `MOLECULE_MACHINE_PRESET=thinkpad_t16_gen2 make test` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_689b90f95ebc83329078d67269989d08