### PR TITLE
Use SSH for dotfiles and configure SSH agent

### DIFF
--- a/tasks/dotfiles.yml
+++ b/tasks/dotfiles.yml
@@ -8,9 +8,10 @@
 
 - name: Clone dotfiles repo
   ansible.builtin.git:
-    repo: https://github.com/PcKiLl3r/.dotfiles.git
-    dest: ~/.dotfiles
+    repo: "git@github.com:PcKiLl3r/.dotfiles.git"
+    dest: "~/.dotfiles"
     version: master
+    key_file: "/home/{{ username }}/.ssh/id_rsa"
   become: true
   become_user: "{{ username }}"
 

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -24,3 +24,18 @@
     force: false
   when: not machine_upgrade
   become: false
+
+- name: Ensure GitHub is a known host
+  ansible.builtin.known_hosts:
+    name: github.com
+    key: "{{ lookup('pipe', 'ssh-keyscan -t rsa github.com') }}"
+  become: false
+
+- name: Add SSH key to agent
+  ansible.builtin.command:
+    cmd: ssh-add ~/.ssh/id_rsa
+  environment:
+    SSH_AUTH_SOCK: "{{ ansible_env.SSH_AUTH_SOCK }}"
+  changed_when: false
+  when: ansible_env.SSH_AUTH_SOCK is defined
+  become: false


### PR DESCRIPTION
## Summary
- use SSH URL with key for dotfiles cloning
- ensure GitHub is trusted and add private key to ssh-agent

## Testing
- `pre-commit run --files tasks/dotfiles.yml tasks/ssh.yml`
- `yamllint tasks/dotfiles.yml tasks/ssh.yml`
- `ansible-lint tasks/dotfiles.yml tasks/ssh.yml` *(fails: Unknown error when attempting to call Galaxy)*
- `ansible-playbook main.yml --start-at-task "Clone dotfiles repo"` *(fails: The vault password file .ansible_vault_pass was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f1fc6bfe08332a8998266f7347a1e