### PR TITLE
Make dotfiles repository configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Key options available in the configuration file:
   - `install_quickshell`: install the Quickshell Wayland panel.
   - `install_rog_packages`: install ROG-specific packages.
 - Other flags: `install_bluetooth`, `install_codecs`, `install_brave`, `install_firefox`, `install_chromium`.
+- `dotfiles_repo`: URL of the git repository containing your dotfiles. Leave empty to skip cloning.
+- `dotfiles_repo_key`: optional path to an SSH private key for a private dotfiles repository.
 
 ### Presets
 Presets allow you to copy machine-specific dotfiles or configuration snippets

--- a/config.template.yml
+++ b/config.template.yml
@@ -22,6 +22,13 @@ install_bluetooth: false
 # Install multimedia codecs like ffmpeg and gstreamer.
 install_codecs: false
 
+# Dotfiles repository to clone. Leave empty to skip dotfiles setup.
+dotfiles_repo: "https://github.com/PcKiLl3r/.dotfiles.git"
+
+# Optional SSH key used to access the dotfiles repository.
+# Leave empty when using HTTPS or the default SSH key.
+dotfiles_repo_key: ""
+
 # Hyprland optional feature flags (effective only when window_manager is 'hyprland')
 
 # Add the current user to the input group (required for some input devices).

--- a/config.yml
+++ b/config.yml
@@ -22,6 +22,13 @@ install_bluetooth: false
 # Install multimedia codecs like ffmpeg and gstreamer.
 install_codecs: false
 
+# Dotfiles repository to clone. Leave empty to skip dotfiles setup.
+dotfiles_repo: "https://github.com/PcKiLl3r/.dotfiles.git"
+
+# Optional SSH key used to access the dotfiles repository.
+# Leave empty when using HTTPS or the default SSH key.
+dotfiles_repo_key: ""
+
 # Hyprland optional feature flags (effective only when window_manager is 'hyprland')
 
 # Add the current user to the input group (required for some input devices).

--- a/main.yml
+++ b/main.yml
@@ -106,6 +106,7 @@
     - name: Import dotfiles setup
       ansible.builtin.import_tasks:
         file: ./tasks/dotfiles.yml
+      when: dotfiles_repo | default('') | length > 0
 
     - name: Import machine preset overrides
       ansible.builtin.import_tasks:

--- a/tasks/dotfiles.yml
+++ b/tasks/dotfiles.yml
@@ -8,10 +8,10 @@
 
 - name: Clone dotfiles repo
   ansible.builtin.git:
-    repo: "git@github.com:PcKiLl3r/.dotfiles.git"
+    repo: "{{ dotfiles_repo }}"
     dest: "~/.dotfiles"
     version: master
-    key_file: "/home/{{ username }}/.ssh/id_rsa"
+    key_file: "{{ dotfiles_repo_key | default(omit, true) }}"
   become: true
   become_user: "{{ username }}"
 


### PR DESCRIPTION
## Summary
- allow configuring dotfiles repository and optional SSH key
- skip dotfiles tasks when repository unset
- document new dotfiles configuration options

## Testing
- `make lint` *(fails: Unknown error attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_689f3a8bb65c833286ae1465e44e9249