### PR TITLE
feat: add Molecule container check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,3 +78,8 @@ clean:
 	@echo "Cleaning up..."
 	find . -type f -name '*.pyc' -delete
 	find . -type d -name '__pycache__' -delete
+	@$(MAKE) molecule-ps
+
+# Check for lingering Molecule containers
+molecule-ps:
+	@./scripts/molecule-ps.sh

--- a/README.md
+++ b/README.md
@@ -153,9 +153,10 @@ The Makefile exposes several common development tasks:
 - `make install` – Install lint tools and Ansible requirements
 - `make install-lint` – Install all linting tools
 - `make install-requirements` – Install Ansible roles and collections
-- `make clean` – Clean up temporary files
+- `make clean` – Clean up temporary files and warn about lingering Molecule containers
 - `make all` – Run linting, syntax checks, and Molecule tests
 - `make help` – List available commands
+- `make molecule-ps` – Warn if Molecule containers are still running
 
 Use `make converge` (or `molecule converge`) for a quick iterative run without
 destroying the test container. When you're satisfied with the result, run

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,6 +20,7 @@ platforms:
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
+    labels: {project: linux-dev-playbook}
 provisioner:
   name: ansible
   playbooks:

--- a/scripts/molecule-ps.sh
+++ b/scripts/molecule-ps.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+containers=$(docker ps -q --filter "label=project=linux-dev-playbook")
+if [ -n "$containers" ]; then
+  echo "Warning: lingering containers with label project=linux-dev-playbook found:"
+  docker ps --filter "label=project=linux-dev-playbook"
+else
+  echo "No molecule containers found."
+fi


### PR DESCRIPTION
## Summary
- tag Molecule containers with project label
- warn about lingering Molecule containers via make molecule-ps

## Testing
- `make lint` *(fails: Unknown error when attempting to call Galaxy: 403 Forbidden)*
- `make molecule-ps` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689f3b938c1083328be05fdc592f97b6