### PR TITLE
Ensure GitHub known host is added idempotently

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -28,7 +28,7 @@
 - name: Ensure GitHub is a known host
   ansible.builtin.known_hosts:
     name: github.com
-    key: "{{ lookup('pipe', 'ssh-keyscan -t rsa github.com') }}"
+    key: "{{ lookup('pipe', 'ssh-keyscan -t rsa github.com 2>/dev/null | grep -v "^#" | head -n 1') }}"
   become: false
 
 - name: Add SSH key to agent


### PR DESCRIPTION
## Summary
- filter `ssh-keyscan` output so GitHub known host key is stable

## Testing
- `MOLECULE_MACHINE_PRESET=thinkpad_t16_gen2 make test` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_689f722507dc833286bdd30eef80e72c