### PR TITLE
Add make target to run Molecule tests without destroying instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ help:
 	@echo "Available commands:"
 	@echo "  make lint            - Run all linters and syntax checks (yamllint, ansible-playbook syntax check, ansible-lint)"
 	@echo "  make test            - Run linting and Molecule tests"
+	@echo "  make test-nodestr    - Run linting and Molecule tests without destroying instances"
 	@echo "  make converge        - Run linting and Molecule converge"
 	@echo "  make converge-at     - Converge but start at a specific task (use START_AT=\"...\")"
 	@echo "  make run             - Execute the main Ansible playbook"
@@ -65,6 +66,11 @@ run:
 test: install-test-tools lint
 	@echo "Running Molecule tests..."
 	$(MOLECULE) test
+
+# Run Molecule tests without destroying instances
+test-nodestr: install-test-tools lint
+	@echo "Running Molecule tests without destroying instances..."
+	$(MOLECULE) test --destroy=never
 
 # Optional: scenario pass-through: use with SCENARIO=<name>
 SCEN_ARG := $(if $(SCENARIO),-s $(SCENARIO),)

--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ molecule converge
 
 When finished, destroy the container with `molecule destroy`.
 
+Alternatively, run the full test sequence and keep the instance alive:
+
+```bash
+MOLECULE_MACHINE_PRESET=thinkpad_t16_gen2 make test-nodestr
+molecule converge
+```
+
+The `test-nodestr` target skips the final cleanup step so you can rerun `molecule converge` as needed.
+
 ## Linting and tests
 Run the linting tools and install role requirements before invoking any of the Makefile targets:
 
@@ -152,6 +161,7 @@ The Makefile exposes several common development tasks:
 - `make run` – Execute the main Ansible playbook (uses `vault/vault_pass.txt` by default)
 - `make lint` – Run yamllint, ansible-playbook syntax check, and ansible-lint
 - `make test` – Run linting and Molecule tests
+- `make test-nodestr` – Run linting and Molecule tests without destroying the container
 - `make converge` – Run linting and Molecule converge
 - `make install` – Install lint tools and Ansible requirements
 - `make install-lint` – Install all linting tools


### PR DESCRIPTION
## Summary
- expose `make test-nodestr` to run `molecule test --destroy=never`
- document keeping Molecule instances alive for iterative converges

## Testing
- `make help`
- `make lint` *(fails: staticdev.brave role could not be downloaded, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f730bd448833286528c6ecc898f63