### PR TITLE
feat: add ideapad 330 machine preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ Run the ThinkPad T16 Gen 2 preset on the default Fedora image:
 MOLECULE_MACHINE_PRESET=thinkpad_t16_gen2 make test
 ```
 
+Run the Lenovo Ideapad 330 preset on the default Fedora image:
+
+```bash
+MOLECULE_MACHINE_PRESET=ideapad_330 make test
+```
+
 To test a different distribution, override the Docker image and container name:
 
 ```bash

--- a/inventory/host_vars/ideapad_330.yml
+++ b/inventory/host_vars/ideapad_330.yml
@@ -1,0 +1,37 @@
+---
+# Configuration options
+os_override: ""  # options: "", "arch", "fedora"
+machine_preset: ""  # options: "", "4k"
+window_manager: i3  # options: "i3", "hyprland"
+install_bluetooth: false  # options: true, false
+install_codecs: false  # options: true, false
+add_input_group: false  # options: true, false
+install_sddm: false  # options: true, false
+install_gtk_themes: false  # options: true, false
+install_thunar: false  # options: true, false
+install_quickshell: false  # options: true, false
+install_rog_packages: false  # options: true, false
+install_brave: true  # options: true, false
+install_firefox: true  # options: true, false
+install_chromium: false  # options: true, false
+
+# User-specific variables
+username: "pckill3r"  # options: any username
+email: "pckill3r@gmail.com"  # options: any email
+ssh_key_filename: "id_pckill3r_rsa"  # options: any SSH key filename
+home: "/home/{{ username }}"  # options: path to home directory
+personal: "{{ home }}/personal"  # options: path to personal directory
+dev: "{{ personal }}/linux-dev-playbook"  # options: path to repository
+
+# Playbook behavior
+use_on_tv: false  # options: true, false
+restore_last_ssh: true  # options: true, false
+
+# Machine-specific packages
+drivers:  # options: add or remove drivers as needed
+  - intel-microcode
+power_management:  # options: add or remove power tools as needed
+  - tlp
+  - powertop
+hardware_packages:  # options: add or remove hardware packages as needed
+  - fwupd

--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -7,3 +7,5 @@ all:
       ansible_host: thinkpad_x240
     desktop_nvidia_780ti:
       ansible_host: desktop_nvidia_780ti
+    ideapad_330:
+      ansible_host: ideapad_330


### PR DESCRIPTION
## Summary
- add Lenovo Ideapad 330 host variables and preset directory
- document how to test the Ideapad 330 preset with Molecule
- register Ideapad 330 in the Ansible inventory

## Testing
- `ansible-galaxy install -r requirements.yml --ignore-errors` *(fails: Tunnel connection failed: 403 Forbidden)*
- `ansible-galaxy collection install -r collections/requirements.yml -p ./collections --ignore-errors`
- `yamllint .`
- `ansible-lint main.yml tasks/` *(fails: Tunnel connection failed: 403 Forbidden)*
- `MOLECULE_MACHINE_PRESET=ideapad_330 make test` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a033d08a888332a60eb0a9de6fa988