### PR TITLE
Add desktop environment and pgModeler options

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,30 @@ Key options available in the configuration file:
 
 - `machine_preset`: name of a preset under `resources/presets/` to copy machine-specific files.
 - `window_manager`: choose `i3` or `hyprland`.
+- `desktop_environment`: choose a desktop environment (`gnome`, `kde`, `xfce`, or `none`).
+- `file_manager`: choose a file manager (`thunar`, `nautilus`, or `none`).
+- `code_editors`: list of code editors to install (`neovim`, `vim`, `vscode`).
+- `terminal_emulator`: choose a terminal emulator (`alacritty`, `kitty`, or `none`).
+- `shell`: choose the default shell (`bash`, `zsh`, or `fish`).
+- `ai_tool`: choose an AI or productivity tool (`clickup` or `none`).
+- `video_player`: choose a video player (`vlc`, `mpv`, or `none`).
+- `torrent_client`: choose a torrent client (`qbittorrent`, `transmission`, or `none`).
+- `terminal_file_manager`: choose a terminal file manager (`yazi`, `ranger`, or `none`).
+- `app_launcher`: choose an application launcher (`rofi`, `wofi`, or `none`).
+- `install_audacity`: set to `true` to install the Audacity audio editor.
+- `install_qalculate`: set to `true` to install the Qalculate calculator.
+- `install_calcurse`: set to `true` to install the Calcurse terminal calendar.
+- `install_dbeaver`: set to `true` to install the DBeaver database tool.
+- `install_pgmodeler`: set to `true` to install the pgModeler database modeler.
+- `install_graphviz`: set to `true` to install Graphviz visualization tools.
+- `install_dia`: set to `true` to install the Dia diagram editor.
+
+- `install_gimp`: set to `true` to install the GIMP image editor.
+- `install_inkscape`: set to `true` to install the Inkscape vector editor.
 - Hyprland extras (effective only when `window_manager` is `hyprland`):
   - `add_input_group`: add the current user to the `input` group.
   - `install_sddm`: install the SDDM display manager and themes.
   - `install_gtk_themes`: install additional GTK themes.
-  - `install_thunar`: install the Thunar file manager.
   - `install_quickshell`: install the Quickshell Wayland panel.
   - `install_rog_packages`: install ROG-specific packages.
 - Other flags: `install_bluetooth`, `install_codecs`, `install_brave`, `install_firefox`, `install_chromium`.

--- a/config.template.yml
+++ b/config.template.yml
@@ -16,6 +16,63 @@ machine_preset: ""
 # optional Wayland features below.
 window_manager: i3
 
+# Choose which desktop environment to install ('gnome', 'kde', 'xfce', or 'none').
+desktop_environment: none
+
+# Choose which file manager to install ('thunar', 'nautilus', or 'none').
+file_manager: none
+
+# List of code editors to install (any of 'neovim', 'vim', 'vscode').
+code_editors:
+  - neovim
+
+# Choose which terminal emulator to install ('alacritty', 'kitty', or 'none').
+terminal_emulator: none
+
+# Choose which shell to use ('bash', 'zsh', or 'fish').
+shell: zsh
+
+# Choose which AI or productivity tool to install ('clickup' or 'none').
+ai_tool: none
+
+# Choose which video player to install ('vlc', 'mpv', or 'none').
+video_player: none
+# Choose which torrent client to install ('qbittorrent', 'transmission', or 'none').
+torrent_client: none
+
+# Choose which terminal file manager to install ('yazi', 'ranger', or 'none').
+terminal_file_manager: none
+
+# Choose which application launcher to install ('rofi', 'wofi', or 'none').
+app_launcher: none
+
+
+# Install graphics applications
+install_gimp: false
+install_inkscape: false
+
+# Install audio editor
+install_audacity: false
+
+# Install calculator
+install_qalculate: false
+
+# Install terminal calendar
+install_calcurse: false
+
+# Install database tool
+install_dbeaver: false
+
+# Install database modeler
+install_pgmodeler: false
+
+# Install graph visualization tools
+install_graphviz: false
+
+# Install diagram editor
+install_dia: false
+
+
 # Install Bluetooth and audio support.
 install_bluetooth: false
 
@@ -42,9 +99,6 @@ install_sddm: false
 
 # Install additional GTK themes for aesthetic customization.
 install_gtk_themes: false
-
-# Install the Thunar file manager.
-install_thunar: false
 
 # Install the Quickshell Wayland panel.
 install_quickshell: false

--- a/config.yml
+++ b/config.yml
@@ -16,6 +16,63 @@ machine_preset: "thinkpad_t16_gen2"
 # optional Wayland features below.
 window_manager: i3
 
+# Choose which desktop environment to install ('gnome', 'kde', 'xfce', or 'none').
+desktop_environment: none
+
+# Choose which file manager to install ('thunar', 'nautilus', or 'none').
+file_manager: none
+
+# List of code editors to install (any of 'neovim', 'vim', 'vscode').
+code_editors:
+  - neovim
+
+# Choose which terminal emulator to install ('alacritty', 'kitty', or 'none').
+terminal_emulator: none
+
+# Choose which shell to use ('bash', 'zsh', or 'fish').
+shell: zsh
+
+# Choose which AI or productivity tool to install ('clickup' or 'none').
+ai_tool: none
+
+# Choose which video player to install ('vlc', 'mpv', or 'none').
+video_player: none
+# Choose which torrent client to install ('qbittorrent', 'transmission', or 'none').
+torrent_client: none
+
+# Choose which terminal file manager to install ('yazi', 'ranger', or 'none').
+terminal_file_manager: none
+
+# Choose which application launcher to install ('rofi', 'wofi', or 'none').
+app_launcher: none
+
+
+# Install graphics applications
+install_gimp: false
+install_inkscape: false
+
+# Install audio editor
+install_audacity: false
+
+# Install calculator
+install_qalculate: false
+
+# Install terminal calendar
+install_calcurse: false
+
+# Install database tool
+install_dbeaver: false
+
+# Install database modeler
+install_pgmodeler: false
+
+# Install graph visualization tools
+install_graphviz: false
+
+# Install diagram editor
+install_dia: false
+
+
 # Install Bluetooth and audio support.
 install_bluetooth: false
 
@@ -42,9 +99,6 @@ install_sddm: false
 
 # Install additional GTK themes for aesthetic customization.
 install_gtk_themes: false
-
-# Install the Thunar file manager.
-install_thunar: false
 
 # Install the Quickshell Wayland panel.
 install_quickshell: false

--- a/inventory/host_vars/desktop_nvidia_780ti.yml
+++ b/inventory/host_vars/desktop_nvidia_780ti.yml
@@ -3,12 +3,32 @@
 os_override: ""  # options: "", "arch", "fedora"
 machine_preset: ""  # options: "", "4k"
 window_manager: i3  # options: "i3", "hyprland"
+desktop_environment: none  # options: "gnome", "kde", "xfce", "none"
+file_manager: none  # options: "thunar", "nautilus", "none"
+code_editors:  # options: "neovim", "vim", "vscode"
+  - neovim
+terminal_emulator: none  # options: "alacritty", "kitty", "none"
+shell: zsh  # options: "bash", "zsh", "fish"
+ai_tool: none  # options: "clickup", "none"
+video_player: none  # options: "vlc", "mpv", "none"
+torrent_client: none  # options: "qbittorrent", "transmission", "none"
+terminal_file_manager: none  # options: "yazi", "ranger", "none"
+app_launcher: none  # options: "rofi", "wofi", "none"
+install_audacity: false  # options: true, false
+install_qalculate: false  # options: true, false
+install_calcurse: false  # options: true, false
+install_dbeaver: false  # options: true, false
+install_pgmodeler: false  # options: true, false
+install_graphviz: false  # options: true, false
+install_dia: false  # options: true, false
+
+install_gimp: false  # options: true, false
+install_inkscape: false  # options: true, false
 install_bluetooth: false  # options: true, false
 install_codecs: false  # options: true, false
 add_input_group: false  # options: true, false
 install_sddm: false  # options: true, false
 install_gtk_themes: false  # options: true, false
-install_thunar: false  # options: true, false
 install_quickshell: false  # options: true, false
 install_rog_packages: false  # options: true, false
 install_brave: true  # options: true, false

--- a/inventory/host_vars/ideapad_330.yml
+++ b/inventory/host_vars/ideapad_330.yml
@@ -3,12 +3,32 @@
 os_override: ""  # options: "", "arch", "fedora"
 machine_preset: ""  # options: "", "4k"
 window_manager: i3  # options: "i3", "hyprland"
+desktop_environment: none  # options: "gnome", "kde", "xfce", "none"
+file_manager: none  # options: "thunar", "nautilus", "none"
+code_editors:  # options: "neovim", "vim", "vscode"
+  - neovim
+terminal_emulator: none  # options: "alacritty", "kitty", "none"
+shell: zsh  # options: "bash", "zsh", "fish"
+ai_tool: none  # options: "clickup", "none"
+video_player: none  # options: "vlc", "mpv", "none"
+torrent_client: none  # options: "qbittorrent", "transmission", "none"
+terminal_file_manager: none  # options: "yazi", "ranger", "none"
+app_launcher: none  # options: "rofi", "wofi", "none"
+install_audacity: false  # options: true, false
+install_qalculate: false  # options: true, false
+install_calcurse: false  # options: true, false
+install_dbeaver: false  # options: true, false
+install_pgmodeler: false  # options: true, false
+install_graphviz: false  # options: true, false
+install_dia: false  # options: true, false
+
+install_gimp: false  # options: true, false
+install_inkscape: false  # options: true, false
 install_bluetooth: false  # options: true, false
 install_codecs: false  # options: true, false
 add_input_group: false  # options: true, false
 install_sddm: false  # options: true, false
 install_gtk_themes: false  # options: true, false
-install_thunar: false  # options: true, false
 install_quickshell: false  # options: true, false
 install_rog_packages: false  # options: true, false
 install_brave: true  # options: true, false

--- a/inventory/host_vars/thinkpad_t16_gen2.yml
+++ b/inventory/host_vars/thinkpad_t16_gen2.yml
@@ -3,12 +3,32 @@
 os_override: ""  # options: "", "arch", "fedora"
 machine_preset: ""  # options: "", "4k"
 window_manager: i3  # options: "i3", "hyprland"
+desktop_environment: none  # options: "gnome", "kde", "xfce", "none"
+file_manager: none  # options: "thunar", "nautilus", "none"
+code_editors:  # options: "neovim", "vim", "vscode"
+  - neovim
+terminal_emulator: none  # options: "alacritty", "kitty", "none"
+shell: zsh  # options: "bash", "zsh", "fish"
+ai_tool: none  # options: "clickup", "none"
+video_player: none  # options: "vlc", "mpv", "none"
+torrent_client: none  # options: "qbittorrent", "transmission", "none"
+terminal_file_manager: none  # options: "yazi", "ranger", "none"
+app_launcher: none  # options: "rofi", "wofi", "none"
+install_audacity: false  # options: true, false
+install_qalculate: false  # options: true, false
+install_calcurse: false  # options: true, false
+install_dbeaver: false  # options: true, false
+install_pgmodeler: false  # options: true, false
+install_graphviz: false  # options: true, false
+install_dia: false  # options: true, false
+
+install_gimp: false  # options: true, false
+install_inkscape: false  # options: true, false
 install_bluetooth: false  # options: true, false
 install_codecs: false  # options: true, false
 add_input_group: false  # options: true, false
 install_sddm: false  # options: true, false
 install_gtk_themes: false  # options: true, false
-install_thunar: false  # options: true, false
 install_quickshell: false  # options: true, false
 install_rog_packages: false  # options: true, false
 install_brave: true  # options: true, false

--- a/inventory/host_vars/thinkpad_x240.yml
+++ b/inventory/host_vars/thinkpad_x240.yml
@@ -3,12 +3,32 @@
 os_override: ""  # options: "", "arch", "fedora"
 machine_preset: ""  # options: "", "4k"
 window_manager: i3  # options: "i3", "hyprland"
+desktop_environment: none  # options: "gnome", "kde", "xfce", "none"
+file_manager: none  # options: "thunar", "nautilus", "none"
+code_editors:  # options: "neovim", "vim", "vscode"
+  - neovim
+terminal_emulator: none  # options: "alacritty", "kitty", "none"
+shell: zsh  # options: "bash", "zsh", "fish"
+ai_tool: none  # options: "clickup", "none"
+video_player: none  # options: "vlc", "mpv", "none"
+torrent_client: none  # options: "qbittorrent", "transmission", "none"
+terminal_file_manager: none  # options: "yazi", "ranger", "none"
+app_launcher: none  # options: "rofi", "wofi", "none"
+install_audacity: false  # options: true, false
+install_qalculate: false  # options: true, false
+install_calcurse: false  # options: true, false
+install_dbeaver: false  # options: true, false
+install_pgmodeler: false  # options: true, false
+install_graphviz: false  # options: true, false
+install_dia: false  # options: true, false
+
+install_gimp: false  # options: true, false
+install_inkscape: false  # options: true, false
 install_bluetooth: false  # options: true, false
 install_codecs: false  # options: true, false
 add_input_group: false  # options: true, false
 install_sddm: false  # options: true, false
 install_gtk_themes: false  # options: true, false
-install_thunar: false  # options: true, false
 install_quickshell: false  # options: true, false
 install_rog_packages: false  # options: true, false
 install_brave: true  # options: true, false

--- a/main.yml
+++ b/main.yml
@@ -68,9 +68,20 @@
         file: ./tasks/codecs.yml
       when: install_codecs | bool
 
+    - name: Import Bash Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/bash.yml
+      when: shell == 'bash'
+
     - name: Import ZShell Install
       ansible.builtin.import_tasks:
         file: ./tasks/zsh.yml
+      when: shell == 'zsh'
+
+    - name: Import Fish Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/fish.yml
+      when: shell == 'fish'
 
     - name: Import Programming Languages/Runtimes Install
       ansible.builtin.import_tasks:
@@ -83,6 +94,130 @@
     - name: Import NeoVim Install
       ansible.builtin.import_tasks:
         file: ./tasks/neovim.yml
+      when: "'neovim' in code_editors"
+
+    - name: Import Vim Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/vim.yml
+      when: "'vim' in code_editors"
+
+    - name: Import VS Code Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/vscode.yml
+      when: "'vscode' in code_editors"
+
+    - name: Import Alacritty Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/alacritty.yml
+      when: terminal_emulator == 'alacritty'
+
+    - name: Import Kitty Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/kitty.yml
+      when: terminal_emulator == 'kitty'
+
+    - name: Import Thunar Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/thunar.yml
+      when: file_manager == 'thunar'
+
+    - name: Import Nautilus Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/nautilus.yml
+      when: file_manager == 'nautilus'
+
+    - name: Import Yazi Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/yazi.yml
+      when: terminal_file_manager == 'yazi'
+
+    - name: Import Ranger Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/ranger.yml
+      when: terminal_file_manager == 'ranger'
+
+
+    - name: Import ClickUp Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/clickup.yml
+      when: ai_tool == 'clickup'
+
+    - name: Import VLC Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/vlc.yml
+      when: video_player == 'vlc'
+
+    - name: Import MPV Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/mpv.yml
+      when: video_player == 'mpv'
+
+    - name: Import qBittorrent Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/qbittorrent.yml
+      when: torrent_client == 'qbittorrent'
+
+    - name: Import Transmission Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/transmission.yml
+      when: torrent_client == 'transmission'
+
+    - name: Import Rofi Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/rofi.yml
+      when: app_launcher == 'rofi'
+
+    - name: Import Wofi Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/wofi.yml
+      when: app_launcher == 'wofi'
+
+
+    - name: Import GIMP Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/gimp.yml
+      when: install_gimp | bool
+
+    - name: Import Inkscape Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/inkscape.yml
+      when: install_inkscape | bool
+
+    - name: Import Audacity Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/audacity.yml
+      when: install_audacity | bool
+
+    - name: Import Qalculate Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/qalculate.yml
+      when: install_qalculate | bool
+
+    - name: Import Calcurse Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/calcurse.yml
+      when: install_calcurse | bool
+
+    - name: Import DBeaver Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/dbeaver.yml
+      when: install_dbeaver | bool
+
+    - name: Import pgModeler Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/pgmodeler.yml
+      when: install_pgmodeler | bool
+
+    - name: Import Graphviz Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/graphviz.yml
+      when: install_graphviz | bool
+
+    - name: Import Dia Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/dia.yml
+      when: install_dia | bool
+
 
     - name: Import i3 Install
       ansible.builtin.import_tasks:
@@ -93,6 +228,21 @@
       ansible.builtin.import_tasks:
         file: ./tasks/hyprland.yml
       when: window_manager == 'hyprland'
+
+    - name: Import GNOME Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/gnome.yml
+      when: desktop_environment == 'gnome'
+
+    - name: Import KDE Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/kde.yml
+      when: desktop_environment == 'kde'
+
+    - name: Import XFCE Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/xfce.yml
+      when: desktop_environment == 'xfce'
 
     - name: Import keyboard setup
       ansible.builtin.import_tasks:

--- a/tasks/alacritty.yml
+++ b/tasks/alacritty.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Alacritty
+  ansible.builtin.package:
+    name: "{{ alacritty_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/audacity.yml
+++ b/tasks/audacity.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Audacity audio editor
+  ansible.builtin.package:
+    name: "{{ audacity_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/bash.yml
+++ b/tasks/bash.yml
@@ -1,0 +1,11 @@
+---
+- name: Ensure Bash is installed
+  ansible.builtin.package:
+    name: "{{ bash_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"
+
+- name: Ensure bash is the default shell
+  ansible.builtin.user:
+    name: "{{ username }}"
+    shell: "/usr/bin/bash"

--- a/tasks/calcurse.yml
+++ b/tasks/calcurse.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Calcurse calendar
+  ansible.builtin.package:
+    name: "{{ calcurse_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/clickup.yml
+++ b/tasks/clickup.yml
@@ -1,0 +1,6 @@
+---
+- name: Install ClickUp
+  ansible.builtin.package:
+    name: "{{ clickup_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/dbeaver.yml
+++ b/tasks/dbeaver.yml
@@ -1,0 +1,6 @@
+---
+- name: Install DBeaver database tool
+  ansible.builtin.package:
+    name: "{{ dbeaver_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/dia.yml
+++ b/tasks/dia.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Dia diagram editor
+  ansible.builtin.package:
+    name: "{{ dia_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/fish.yml
+++ b/tasks/fish.yml
@@ -1,0 +1,11 @@
+---
+- name: Ensure Fish shell is installed
+  ansible.builtin.package:
+    name: "{{ fish_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"
+
+- name: Ensure fish is the default shell
+  ansible.builtin.user:
+    name: "{{ username }}"
+    shell: "/usr/bin/fish"

--- a/tasks/gimp.yml
+++ b/tasks/gimp.yml
@@ -1,0 +1,6 @@
+---
+- name: Install GIMP image editor
+  ansible.builtin.package:
+    name: "{{ gimp_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/gnome.yml
+++ b/tasks/gnome.yml
@@ -1,0 +1,6 @@
+---
+- name: Install GNOME desktop environment
+  ansible.builtin.package:
+    name: "{{ gnome_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/graphviz.yml
+++ b/tasks/graphviz.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Graphviz visualization tools
+  ansible.builtin.package:
+    name: "{{ graphviz_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/hyprland.yml
+++ b/tasks/hyprland.yml
@@ -25,12 +25,6 @@
     state: present
     use: "{{ pkg_mgr }}"
   when: install_gtk_themes | bool
-- name: Install Thunar file manager
-  ansible.builtin.package:
-    name: "{{ hyprland_thunar_packages }}"
-    state: present
-    use: "{{ pkg_mgr }}"
-  when: install_thunar | bool
 
 - name: Install Quickshell
   ansible.builtin.package:

--- a/tasks/inkscape.yml
+++ b/tasks/inkscape.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Inkscape vector editor
+  ansible.builtin.package:
+    name: "{{ inkscape_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/kde.yml
+++ b/tasks/kde.yml
@@ -1,0 +1,6 @@
+---
+- name: Install KDE Plasma desktop environment
+  ansible.builtin.package:
+    name: "{{ kde_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/kitty.yml
+++ b/tasks/kitty.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Kitty
+  ansible.builtin.package:
+    name: "{{ kitty_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/mpv.yml
+++ b/tasks/mpv.yml
@@ -1,0 +1,6 @@
+---
+- name: Install MPV video player
+  ansible.builtin.package:
+    name: "{{ mpv_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/nautilus.yml
+++ b/tasks/nautilus.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Nautilus file manager
+  ansible.builtin.package:
+    name: "{{ nautilus_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/pgmodeler.yml
+++ b/tasks/pgmodeler.yml
@@ -1,0 +1,6 @@
+---
+- name: Install pgModeler database modeler
+  ansible.builtin.package:
+    name: "{{ pgmodeler_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/qalculate.yml
+++ b/tasks/qalculate.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Qalculate calculator
+  ansible.builtin.package:
+    name: "{{ qalculate_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/qbittorrent.yml
+++ b/tasks/qbittorrent.yml
@@ -1,0 +1,6 @@
+---
+- name: Install qBittorrent
+  ansible.builtin.package:
+    name: "{{ qbittorrent_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/ranger.yml
+++ b/tasks/ranger.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Ranger terminal file manager
+  ansible.builtin.package:
+    name: "{{ ranger_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/rofi.yml
+++ b/tasks/rofi.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Rofi application launcher
+  ansible.builtin.package:
+    name: "{{ rofi_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/thunar.yml
+++ b/tasks/thunar.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Thunar file manager
+  ansible.builtin.package:
+    name: "{{ thunar_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/transmission.yml
+++ b/tasks/transmission.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Transmission
+  ansible.builtin.package:
+    name: "{{ transmission_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/vim.yml
+++ b/tasks/vim.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Vim editor
+  ansible.builtin.package:
+    name: "{{ vim_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/vlc.yml
+++ b/tasks/vlc.yml
@@ -1,0 +1,6 @@
+---
+- name: Install VLC video player
+  ansible.builtin.package:
+    name: "{{ vlc_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/vscode.yml
+++ b/tasks/vscode.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Visual Studio Code
+  ansible.builtin.package:
+    name: "{{ vscode_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/wofi.yml
+++ b/tasks/wofi.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Wofi application launcher
+  ansible.builtin.package:
+    name: "{{ wofi_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/xfce.yml
+++ b/tasks/xfce.yml
@@ -1,0 +1,6 @@
+---
+- name: Install XFCE desktop environment
+  ansible.builtin.package:
+    name: "{{ xfce_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/tasks/yazi.yml
+++ b/tasks/yazi.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Yazi terminal file manager
+  ansible.builtin.package:
+    name: "{{ yazi_packages }}"
+    state: present
+    use: "{{ pkg_mgr }}"

--- a/vars/arch.yml
+++ b/vars/arch.yml
@@ -56,6 +56,12 @@ dotfiles_packages:
 zsh_packages:
   - zsh
 
+bash_packages:
+  - bash
+
+fish_packages:
+  - fish
+
 i3_packages:
   - i3-wm
   - i3status
@@ -75,9 +81,39 @@ hyprland_sddm_packages:
 hyprland_gtk_packages:
   - gtk-engine-murrine
 
-hyprland_thunar_packages:
+thunar_packages:
   - thunar
   - thunar-volman
+
+nautilus_packages:
+  - nautilus
+
+vim_packages:
+  - vim
+
+vscode_packages:
+  - code
+
+alacritty_packages:
+  - alacritty
+
+kitty_packages:
+  - kitty
+
+clickup_packages:
+  - clickup-desktop
+
+vlc_packages:
+  - vlc
+
+mpv_packages:
+  - mpv
+
+gimp_packages:
+  - gimp
+
+inkscape_packages:
+  - inkscape
 
 hyprland_quickshell_packages:
   - quickshell
@@ -153,3 +189,37 @@ prog_lang_go_packages:
 prog_lang_lua_packages:
   - lua
   - luarocks
+
+yazi_packages:
+  - yazi
+ranger_packages:
+  - ranger
+rofi_packages:
+  - rofi
+wofi_packages:
+  - wofi
+qbittorrent_packages:
+  - qbittorrent
+transmission_packages:
+  - transmission-gtk
+audacity_packages:
+  - audacity
+qalculate_packages:
+  - qalculate-gtk
+calcurse_packages:
+  - calcurse
+dbeaver_packages:
+  - dbeaver
+graphviz_packages:
+  - graphviz
+dia_packages:
+  - dia
+pgmodeler_packages:
+  - pgmodeler
+gnome_packages:
+  - gnome
+kde_packages:
+  - plasma
+xfce_packages:
+  - xfce4
+  - xfce4-goodies

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -54,6 +54,12 @@ dotfiles_packages:
 zsh_packages:
   - zsh
 
+bash_packages:
+  - bash
+
+fish_packages:
+  - fish
+
 i3_packages:
   - i3
   - i3status
@@ -73,9 +79,39 @@ hyprland_sddm_packages:
 hyprland_gtk_packages:
   - gtk-murrine-engine
 
-hyprland_thunar_packages:
+thunar_packages:
   - thunar
   - thunar-volman
+
+nautilus_packages:
+  - nautilus
+
+vim_packages:
+  - vim
+
+vscode_packages:
+  - code
+
+alacritty_packages:
+  - alacritty
+
+kitty_packages:
+  - kitty
+
+clickup_packages:
+  - clickup-desktop
+
+vlc_packages:
+  - vlc
+
+mpv_packages:
+  - mpv
+
+gimp_packages:
+  - gimp
+
+inkscape_packages:
+  - inkscape
 
 hyprland_quickshell_packages:
   - quickshell
@@ -151,3 +187,36 @@ prog_lang_go_packages:
 prog_lang_lua_packages:
   - lua
   - luarocks
+
+yazi_packages:
+  - yazi
+ranger_packages:
+  - ranger
+rofi_packages:
+  - rofi
+wofi_packages:
+  - wofi
+qbittorrent_packages:
+  - qbittorrent
+transmission_packages:
+  - transmission-gtk
+audacity_packages:
+  - audacity
+qalculate_packages:
+  - qalculate-gtk
+calcurse_packages:
+  - calcurse
+dbeaver_packages:
+  - dbeaver
+graphviz_packages:
+  - graphviz
+dia_packages:
+  - dia
+pgmodeler_packages:
+  - pgmodeler
+gnome_packages:
+  - gnome-desktop
+kde_packages:
+  - plasma-desktop
+xfce_packages:
+  - xfce-desktop


### PR DESCRIPTION
## Summary
- allow choosing GNOME, KDE, or XFCE via new `desktop_environment` variable
- support installing multiple editors via `code_editors` list
- optional pgModeler database modeling tool

## Testing
- `make lint` *(fails: ansible-galaxy: No such file or directory)*
- `yamllint .` *(command not found)*
- `ansible-lint --offline main.yml tasks/` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a03b25354483328b07131503854730