### PR TITLE
Handle missing real-prog layouts

### DIFF
--- a/tasks/keyboard.yml
+++ b/tasks/keyboard.yml
@@ -22,14 +22,14 @@
 - name: Check for real-prog-dvorak layout
   ansible.builtin.command: grep -q 'real-prog-dvorak' /usr/share/X11/xkb/rules/evdev.xml
   register: dvorak_exists
-  ignore_errors: true
+  failed_when: false
   changed_when: false
   become: true
 
 - name: Check for real-prog-dvo-k layout
   ansible.builtin.command: grep -q 'real-prog-dvo-k' /usr/share/X11/xkb/rules/evdev.xml
   register: dvo_k_exists
-  ignore_errors: true
+  failed_when: false
   changed_when: false
   become: true
 
@@ -63,4 +63,13 @@
         </variantList>
       </layout>
   when: dvorak_exists.rc != 0 or dvo_k_exists.rc != 0
+  become: true
+
+- name: Validate real-prog layouts were inserted
+  ansible.builtin.shell: |
+    grep -q 'real-prog-dvorak' /usr/share/X11/xkb/rules/evdev.xml \
+    && grep -q 'real-prog-dvo-k' /usr/share/X11/xkb/rules/evdev.xml
+  changed_when: false
+  failed_when: result.rc != 0
+  register: result
   become: true


### PR DESCRIPTION
## Summary
- avoid misleading errors when real-prog layouts are absent
- ensure real-prog layouts were inserted into evdev.xml

## Testing
- `make lint` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `yamllint tasks/keyboard.yml`
- `ansible-lint tasks/keyboard.yml` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68a49f0d28188332a3fab51f8af48f98