### PR TITLE
Ensure user has sudo group membership

### DIFF
--- a/tasks/core.yml
+++ b/tasks/core.yml
@@ -6,6 +6,13 @@
     createhome: true
   become_method: ansible.builtin.sudo
 
+- name: Ensure user has sudo privileges
+  ansible.builtin.user:
+    name: "{{ username }}"
+    groups: "{{ 'wheel' if ansible_os_family == 'RedHat' else 'sudo' }}"
+    append: true
+  become: true
+
 # Ensure the dnf Python bindings are available before using the package
 # module on Fedora-based systems. Minimal container images may omit the
 # python3-dnf package which Ansible's dnf backend requires.


### PR DESCRIPTION
## Summary
- ensure created user is added to sudo or wheel group for elevated privileges

## Testing
- `make lint` *(fails: staticdev.brave role download - 403)*
- `yamllint tasks/core.yml`
- `ansible-lint --offline tasks/core.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a49f105c708332b42145c82ec21f80