### PR TITLE
Add YAML and Ansible linting to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,17 @@ repos:
     hooks:
       - id: detect-secrets
         exclude: '^vault/'
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+  - repo: https://github.com/ansible-community/ansible-lint
+    rev: v24.6.1
+    hooks:
+      - id: ansible-lint
+        additional_dependencies:
+          - ansible-core==2.17.13
+        args: [--offline, --skip-list, internal-error]
   - repo: local
     hooks:
       - id: ansible-vault-header

--- a/config.template.yml
+++ b/config.template.yml
@@ -46,7 +46,6 @@ terminal_file_manager: none
 # Choose which application launcher to install ('rofi', 'wofi', or 'none').
 app_launcher: none
 
-
 # Install graphics applications
 install_gimp: false
 install_inkscape: false
@@ -71,7 +70,6 @@ install_graphviz: false
 
 # Install diagram editor
 install_dia: false
-
 
 # Install Bluetooth and audio support.
 install_bluetooth: false

--- a/config.yml
+++ b/config.yml
@@ -46,7 +46,6 @@ terminal_file_manager: none
 # Choose which application launcher to install ('rofi', 'wofi', or 'none').
 app_launcher: none
 
-
 # Install graphics applications
 install_gimp: false
 install_inkscape: false
@@ -71,7 +70,6 @@ install_graphviz: false
 
 # Install diagram editor
 install_dia: false
-
 
 # Install Bluetooth and audio support.
 install_bluetooth: true
@@ -109,4 +107,3 @@ install_rog_packages: false
 # Browser installation flags
 install_brave: true
 install_firefox: true
-

--- a/main.yml
+++ b/main.yml
@@ -136,7 +136,6 @@
         file: ./tasks/ranger.yml
       when: terminal_file_manager == 'ranger'
 
-
     - name: Import ClickUp Install
       ansible.builtin.import_tasks:
         file: ./tasks/clickup.yml
@@ -171,7 +170,6 @@
       ansible.builtin.import_tasks:
         file: ./tasks/wofi.yml
       when: app_launcher == 'wofi'
-
 
     - name: Import GIMP Install
       ansible.builtin.import_tasks:
@@ -217,7 +215,6 @@
       ansible.builtin.import_tasks:
         file: ./tasks/dia.yml
       when: install_dia | bool
-
 
     - name: Import i3 Install
       ansible.builtin.import_tasks:


### PR DESCRIPTION
## Summary
- run YAML syntax checks via yamllint
- enforce Ansible playbook style with ansible-lint
- tidy up YAML spacing to satisfy new hooks

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68a4a4a61c4483329ba7a7097eafe6a2