### PR TITLE
Add Arch Linux Molecule scenario

### DIFF
--- a/molecule/arch/_create.yml
+++ b/molecule/arch/_create.yml
@@ -1,0 +1,53 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Create Docker container
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command | default(omit) }}"
+        privileged: "{{ item.privileged | default(omit) }}"
+        volumes: "{{ item.volumes | default(omit) }}"
+        cgroupns_mode: "{{ item.cgroupns_mode | default(omit) }}"
+        pre_build_image: true
+        state: started
+      loop: "{{ molecule_yml.platforms }}"
+      register: server
+      async: 300
+      poll: 0
+
+    - name: Wait for containers to start
+      ansible.builtin.async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: _wait
+      until: _wait.finished
+      retries: 30
+      delay: 1
+      loop: "{{ server.results }}"
+
+    - name: Populate instance config dict
+      ansible.builtin.set_fact:
+        instance_conf_dict:
+          instance: "{{ item.item.name }}"
+          address: "{{ item.invocation.module_args.name }}"
+          user: root
+          port: 22
+          identity_file: ""
+      loop: "{{ _wait.results }}"
+      register: instance_config_dict
+
+    - name: Convert instance config dict to a list
+      ansible.builtin.set_fact:
+        instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+
+    - name: Dump instance config
+      ansible.builtin.copy:
+        content: |
+          # Molecule managed
+
+          {{ instance_conf | to_json | from_json | to_yaml }}
+        dest: "{{ molecule_instance_config }}"
+        mode: "0600"

--- a/molecule/arch/_destroy.yml
+++ b/molecule/arch/_destroy.yml
@@ -1,0 +1,28 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Destroy Docker container
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        state: absent
+      loop: "{{ molecule_yml.platforms }}"
+      register: server
+
+    # Mandatory configuration for Molecule to function.
+
+    - name: Populate instance config
+      ansible.builtin.set_fact:
+        instance_conf: {}
+
+    - name: Dump instance config
+      ansible.builtin.copy:
+        content: |
+          # Molecule managed
+
+          {{ instance_conf | to_json | from_json | to_yaml }}
+        dest: "{{ molecule_instance_config }}"
+        mode: "0600"
+      when: server is succeeded

--- a/molecule/arch/cleanup.yml
+++ b/molecule/arch/cleanup.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  gather_facts: false
+  tasks: []

--- a/molecule/arch/converge.yml
+++ b/molecule/arch/converge.yml
@@ -1,0 +1,53 @@
+---
+- name: Converge
+  hosts: all
+
+  tasks:
+
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../vars/common.yml
+
+    - name: Create user
+      ansible.builtin.user:
+        name: "{{ username }}"
+        state: present
+        createhome: true
+      become: true
+      become_method: "sudo"
+
+    - name: Install dependencies to mirror real environment
+      ansible.builtin.package:
+        name:
+          - git
+        state: present
+
+    - name: Clone this repo to mirror real environment
+      ansible.builtin.git:
+        repo: https://github.com/PcKiLl3r/linux-dev-playbook.git
+        dest: ~/personal/linux-dev-playbook
+      become: true
+      become_user: "{{ username }}"
+
+    - name: Update apt cache (on Debian based systems only)
+      apt:
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_os_family == 'Debian'
+
+    - name: Update pacman cache (on Arch based systems only)
+      community.general.pacman:
+        update_cache: true
+      when: ansible_os_family == 'Archlinux'
+
+    - name: Set machine preset for tests
+      ansible.builtin.lineinfile:
+        path: "{{ playbook_dir }}/../../config.yml"
+        regexp: '^machine_preset:'
+        line: "machine_preset: \"{{ lookup('ansible.builtin.env', 'MOLECULE_MACHINE_PRESET') }}\""
+      delegate_to: localhost
+      run_once: true
+      when: lookup('ansible.builtin.env', 'MOLECULE_MACHINE_PRESET') | length > 0
+
+- name: Import Main Playbook
+  import_playbook: ../../main.yml

--- a/molecule/arch/molecule.yml
+++ b/molecule/arch/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: ../../requirements.yml
+    requirements-file: ../../collections/requirements.yml
+    collections-path: ../../collections
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+platforms:
+  - name: "${MOLECULE_DISTRO:-arch}"
+    image: "${MOLECULE_IMAGE:-archlinux:latest}"
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+    labels: {project: linux-dev-playbook}
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: prepare.yml
+    cleanup: cleanup.yml
+verifier:
+  name: ansible

--- a/molecule/arch/prepare.yml
+++ b/molecule/arch/prepare.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Install python and sudo on Arch
+      raw: pacman -Sy --noconfirm python sudo
+      when: inventory_hostname == 'arch'

--- a/molecule/arch/testinventory
+++ b/molecule/arch/testinventory
@@ -1,0 +1,2 @@
+[machines]
+localhost


### PR DESCRIPTION
## Summary
- add Arch Linux Molecule scenario with Arch-based container
- install Arch-specific prerequisites in prepare playbook
- handle pacman cache update during converge

## Testing
- `make test SCENARIO=arch` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/' <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a4f84c4083328d757a63c3bc6534