### PR TITLE
feat: skip git clone when repo exists

### DIFF
--- a/tasks/core.yml
+++ b/tasks/core.yml
@@ -38,6 +38,13 @@
     state: present
     use: "{{ pkg_mgr }}"
 
+- name: Check if linux-dev-playbook repo exists
+  ansible.builtin.stat:
+    path: ~/personal/linux-dev-playbook/.git
+  register: ldp_repo_stat
+  become_user: "{{ username }}"
+  become: true
+
 - name: Clone this repo to mirror real environment
   ansible.builtin.git:
     repo: https://github.com/PcKiLl3r/linux-dev-playbook.git
@@ -45,6 +52,7 @@
     version: master
   become_user: "{{ username }}"
   become: true
+  when: not ldp_repo_stat.stat.exists
 
 - name: Update apt cache (on Debian based systems only)
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary
- avoid redundant git clone by checking for existing working copy

## Testing
- `yamllint tasks/core.yml`
- `make lint` *(fails: Unknown error when attempting to call Galaxy: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68a5f3ce7f0483329d399308a2249831