### PR TITLE
docs: note clone task for remote targets

### DIFF
--- a/docs/fresh-install.md
+++ b/docs/fresh-install.md
@@ -39,3 +39,18 @@ Run the bootstrap script to decrypt vault files, execute the playbook and re-enc
 ```
 
 The playbook installs packages and copies any preset files for the chosen machine. Rerun the script whenever you need to reapply the configuration.
+
+### Handling existing clones
+
+The core tasks include a step that clones this repository on the target host. This is useful for provisioning remote machines but can fail on a workstation where the repository already exists with uncommitted changes.
+
+If you hit an error during the clone step:
+
+- Commit or stash any local changes before running the playbook, or
+- Skip the clone task when invoking Ansible, for example:
+
+  ```bash
+  ansible-playbook main.yml -i localhost, -c local --skip-tags repo_clone
+  ```
+
+  (Alternatively, temporarily comment out the "Clone this repo to mirror real environment" task in `tasks/core.yml`.)


### PR DESCRIPTION
## Summary
- document that the playbook's repo-clone task targets remote hosts and may fail on local checkouts
- add tips for stashing/committing changes or skipping the clone step

## Testing
- `make lint` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `yamllint .`
- `ansible-lint --offline main.yml tasks/` *(fails: internal-error profile:min tags:core)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f3d0a6f08332a9b1aa5afe38cc98