### PR TITLE
Handle missing Chromium flag

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -110,3 +110,4 @@ install_rog_packages: false
 # Browser installation flags
 install_brave: true
 install_firefox: true
+install_chromium: false

--- a/tasks/browsers.yml
+++ b/tasks/browsers.yml
@@ -21,4 +21,4 @@
   ansible.builtin.package:
     name: "{{ 'chromium-browser' if target_os == 'ubuntu' else 'chromium' }}"
     state: present
-  when: install_chromium | bool
+  when: install_chromium | default(false) | bool


### PR DESCRIPTION
## Summary
- avoid undefined variable error when installing Chromium by defaulting `install_chromium`
- document Chromium browser flag in example config

## Testing
- `yamllint .`
- `make lint` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/' - Tunnel connection failed: 403 Forbidden)*
- `ansible-lint main.yml tasks/` *(fails: staticdev.brave role install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6230106fc83329f1f49fb59c98e7a