### PR TITLE
Remove ffmpeg-free libraries before installing codecs

### DIFF
--- a/tasks/codecs.yml
+++ b/tasks/codecs.yml
@@ -1,7 +1,17 @@
 ---
-- name: Remove conflicting ffmpeg-free package
+- name: Remove conflicting ffmpeg-free packages
   ansible.builtin.package:
-    name: ffmpeg-free
+    name:
+      - ffmpeg-free
+      - libavcodec-free
+      - libavdevice-free
+      - libavfilter-free
+      - libavformat-free
+      - libavresample-free
+      - libavutil-free
+      - libpostproc-free
+      - libswresample-free
+      - libswscale-free
     state: absent
     use: "{{ pkg_mgr }}"
   when: pkg_mgr == 'dnf'


### PR DESCRIPTION
## Summary
- remove ffmpeg-free libraries that conflict with RPM Fusion packages before installing multimedia codecs

## Testing
- `pre-commit run --files tasks/codecs.yml`
- `MOLECULE_MACHINE_PRESET=ideapad_330 molecule test` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68a89b64234083328f63edabb8ec283d