### PR TITLE
Run PipeWire services as user

### DIFF
--- a/tasks/bluetooth.yml
+++ b/tasks/bluetooth.yml
@@ -21,6 +21,7 @@
     - pipewire.socket
     - pipewire-pulse.socket
     - wireplumber.service
+  become: false
 
 - name: Create bluetooth reconnect script
   ansible.builtin.copy:


### PR DESCRIPTION
## Summary
- run PipeWire user services without escalation so they're placed in the user's systemd instance

## Testing
- `make lint` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `ansible-playbook -i localhost, -c local /tmp/test_playbook.yml -e bluetooth_packages=[] -e pkg_mgr=apt -e ansible_python_interpreter=/usr/bin/python3 --start-at-task "Enable PipeWire user services"` *(fails: Failed to connect to bus: No such file or directory)*
- `journalctl --user -xe` *(fails: No journal files were found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8aa15e2b08332a2365f4c86baf4a4