### PR TITLE
Fix PipeWire user service units

### DIFF
--- a/tasks/bluetooth.yml
+++ b/tasks/bluetooth.yml
@@ -18,8 +18,8 @@
     enabled: true
     scope: user
   loop:
-    - pipewire.socket
-    - pipewire-pulse.socket
+    - pipewire.service
+    - pipewire-pulse.service
     - wireplumber.service
   become: false
 


### PR DESCRIPTION
## Summary
- ensure PipeWire services are enabled instead of sockets

## Testing
- `make test-nodestr` *(fails: staticdev.brave role installation 403 Forbidden)*
- `yamllint tasks/bluetooth.yml`
- `ansible-lint tasks/bluetooth.yml` *(fails: staticdev.brave role installation 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ad941e1c8332b2618b6bb7d90879