### PR TITLE
Parameterize PipeWire user services

### DIFF
--- a/tasks/bluetooth.yml
+++ b/tasks/bluetooth.yml
@@ -17,10 +17,8 @@
     state: started
     enabled: true
     scope: user
-  loop:
-    - pipewire.service
-    - pipewire-pulse.service
-    - wireplumber.service
+  loop: "{{ pipewire_user_services }}"
+  when: pipewire_user_services | length > 0
   become: false
 
 - name: Create bluetooth reconnect script

--- a/vars/arch.yml
+++ b/vars/arch.yml
@@ -15,6 +15,11 @@ bluetooth_packages:
   - bluez-utils
   - blueman
 
+pipewire_user_services:
+  - pipewire.service
+  - pipewire-pulse.service
+  - wireplumber.service
+
 mobile_dev_packages:
   - scrcpy
 

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -14,6 +14,8 @@ bluetooth_packages:
   - bluez-tools
   - blueman
 
+pipewire_user_services: []
+
 mobile_dev_packages:
   - scrcpy
 


### PR DESCRIPTION
## Summary
- replace hard-coded PipeWire user service list with `pipewire_user_services`
- define `pipewire_user_services` per distribution and skip when empty

## Testing
- `yamllint tasks/bluetooth.yml vars/arch.yml vars/fedora.yml`
- `ansible-lint --offline tasks/bluetooth.yml`
- `ansible-playbook -i localhost, -c local /tmp/pipewire_test.yml -e '{"pipewire_user_services":[]}' --vault-password-file /tmp/vault_pass`


------
https://chatgpt.com/codex/tasks/task_e_68a8b0392c2c8332a80b7376a0b898ca