### PR TITLE
Handle missing bluetooth mac addresses

### DIFF
--- a/tasks/bluetooth.yml
+++ b/tasks/bluetooth.yml
@@ -27,7 +27,7 @@
     mode: '0755'
     content: |
       #!/usr/bin/env bash
-      {% for mac in bluetooth_macs %}
+      {% for mac in bluetooth_macs | default([]) %}
       bluetoothctl connect {{ mac }}
       {% endfor %}
 


### PR DESCRIPTION
## Summary
- prevent bluetooth reconnect script task from failing when `bluetooth_macs` is not defined

## Testing
- `yamllint tasks/bluetooth.yml`
- `MOLECULE_MACHINE_PRESET=ideapad_330 make test-nodestr` *(fails: staticdev.brave was NOT installed successfully: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b4c6e1b48332b3426d5b58280f52