### PR TITLE
Add Intel Wi-Fi firmware setup for Fedora

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -263,6 +263,11 @@
         file: ./tasks/bluetooth.yml
       when: install_bluetooth | bool
 
+    - name: Import Intel Wi-Fi firmware setup
+      ansible.builtin.import_tasks:
+        file: ./tasks/wifi.yml
+      when: target_os == 'fedora' or (install_intel_wifi_firmware | default(false))
+
     - name: Import dotfiles setup
       ansible.builtin.import_tasks:
         file: ./tasks/dotfiles.yml
@@ -271,3 +276,27 @@
     # - name: Import machine preset overrides
     #   ansible.builtin.import_tasks:
     #     file: ./tasks/presets.yml
+
+  handlers:
+    - name: Rebuild initramfs after Intel Wi-Fi firmware update
+      listen: Intel Wi-Fi firmware updated
+      ansible.builtin.command: dracut --force
+      become: true
+      changed_when: true
+      when: target_os == 'fedora'
+
+    - name: Remove Intel Wi-Fi modules
+      listen: Intel Wi-Fi firmware updated
+      ansible.builtin.command: modprobe -r iwlmvm iwlwifi
+      become: true
+      register: intel_wifi_module_unload
+      failed_when: intel_wifi_module_unload.rc not in [0, 1]
+      changed_when: intel_wifi_module_unload.rc == 0
+      when: target_os == 'fedora'
+
+    - name: Reload Intel Wi-Fi module
+      listen: Intel Wi-Fi firmware updated
+      ansible.builtin.command: modprobe iwlwifi
+      become: true
+      changed_when: true
+      when: target_os == 'fedora'

--- a/presets/thinkpad_t16_gen2.yml
+++ b/presets/thinkpad_t16_gen2.yml
@@ -43,6 +43,7 @@ install_graphviz: false
 install_dia: false
 install_bluetooth: true
 install_codecs: true
+install_intel_wifi_firmware: true
 
 # Hyprland specific
 add_input_group: true

--- a/tasks/wifi.yml
+++ b/tasks/wifi.yml
@@ -1,0 +1,54 @@
+---
+- name: Ensure Intel Wi-Fi firmware package is installed
+  ansible.builtin.dnf:
+    name: iwlwifi-mvm-firmware
+    state: present
+  become: true
+  when: target_os == 'fedora'
+  notify: Intel Wi-Fi firmware updated
+
+- name: Ensure firmware directory exists
+  ansible.builtin.file:
+    path: /usr/lib/firmware
+    state: directory
+    mode: "0755"
+  become: true
+
+- name: Check for bundled Intel Wi-Fi firmware assets
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/resources/firmware"
+  register: intel_wifi_firmware_source_stat
+
+- name: Discover Intel Wi-Fi firmware assets
+  ansible.builtin.find:
+    paths: "{{ playbook_dir }}/resources/firmware"
+    patterns: "iwlwifi-so-a0-gf-a0-*"
+    file_type: file
+  register: intel_wifi_firmware_artifacts
+  when: intel_wifi_firmware_source_stat.stat.exists
+
+- name: Categorise Intel Wi-Fi firmware assets
+  ansible.builtin.set_fact:
+    intel_wifi_firmware_copy_files: "{{ intel_wifi_firmware_artifacts.files | map(attribute='path') | select('search', '\\.(ucode|pnvm)$') | list }}"
+    intel_wifi_firmware_archives: "{{ intel_wifi_firmware_artifacts.files | map(attribute='path') | select('search', '\\.(gz|xz|bz2|tgz|tar)$') | list }}"
+  when: intel_wifi_firmware_source_stat.stat.exists
+
+- name: Copy Intel Wi-Fi firmware blobs
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "/usr/lib/firmware/{{ item | basename }}"
+    mode: "0644"
+  become: true
+  loop: "{{ intel_wifi_firmware_copy_files | default([]) }}"
+  when: intel_wifi_firmware_copy_files | default([]) | length > 0
+  notify: Intel Wi-Fi firmware updated
+
+- name: Extract Intel Wi-Fi firmware archives
+  ansible.builtin.unarchive:
+    src: "{{ item }}"
+    dest: /usr/lib/firmware
+    remote_src: false
+  become: true
+  loop: "{{ intel_wifi_firmware_archives | default([]) }}"
+  when: intel_wifi_firmware_archives | default([]) | length > 0
+  notify: Intel Wi-Fi firmware updated


### PR DESCRIPTION
## Summary
- add a dedicated Intel Wi-Fi firmware task that installs the package and copies bundled firmware blobs when present
- wire the new task into the main play for Fedora systems or when the preset flag is enabled
- rebuild initramfs and reload Intel Wi-Fi modules through handlers only when firmware changes occur

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db1e6417c48332acf350f3c290bccb