### PR TITLE
Ensure dotfiles submodules are cloned and stowed once

### DIFF
--- a/presets/thinkpad_t16_gen2.yml
+++ b/presets/thinkpad_t16_gen2.yml
@@ -59,7 +59,7 @@ install_chromium: true
 # Dotfiles
 dotfiles_repo: "https://github.com/PcKiLl3r/.dotfiles.git"
 dotfiles_repo_key: ""
-dotfiles_repo_recursive: false
+dotfiles_repo_recursive: true
 
 # Dotfiles folders to stow
 stow_folders:

--- a/tasks/dotfiles.yml
+++ b/tasks/dotfiles.yml
@@ -12,14 +12,14 @@
     dest: "~/.dotfiles"
     version: master
     key_file: "{{ dotfiles_repo_key | default(omit, true) }}"
-    recursive: "{{ dotfiles_repo_recursive | default(false) }}"
+    recursive: "{{ dotfiles_repo_recursive | default(true) }}"
   become: true
   become_user: "{{ username }}"
 
 - name: Stow .dotfiles
-  ansible.builtin.command:
-    cmd: ./run
-    # creates:
+  ansible.builtin.shell:
+    cmd: ./run && touch .stow-complete
+    creates: "/home/{{ username }}/.dotfiles/.stow-complete"
   args:
     chdir: "/home/{{ username }}/.dotfiles"
   changed_when: false


### PR DESCRIPTION
## Summary
- enable recursive cloning for dotfiles so submodules are available by default
- add a stow completion marker to avoid rerunning the stow script unnecessarily

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db1e651898833296592593772aef2e