### PR TITLE
Add NetworkManager-tui to Fedora utility packages

### DIFF
--- a/tasks/utils.yml
+++ b/tasks/utils.yml
@@ -1,6 +1,11 @@
----
+- name: Determine utility package set
+  ansible.builtin.set_fact:
+    utils_packages_effective: >-
+      {{ utils_packages if install_networkmanager_tui | default(true) | bool
+         else utils_packages | reject('equalto', 'NetworkManager-tui') | list }}
+
 - name: Install Useful Utilities
   ansible.builtin.package:
-    name: "{{ utils_packages }}"
+    name: "{{ utils_packages_effective }}"
     state: present
     use: "{{ pkg_mgr }}"

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -39,6 +39,9 @@ utils_packages:
   - tldr
   - shutter
   - trash-cli
+  - NetworkManager-tui
+
+install_networkmanager_tui: true
 
 virtualization_kernel_deps_packages:
   - "@development-tools"


### PR DESCRIPTION
## Summary
- add NetworkManager-tui to the Fedora utility package defaults
- allow presets to disable the package via install_networkmanager_tui flag
- ensure the utility task installs the conditional package list

## Testing
- `ansible-playbook --syntax-check main.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db1e65ab8c8332aae0a57a36b182f5