### PR TITLE
Add Fedora repository setup for VS Code installations

### DIFF
--- a/tasks/vscode.yml
+++ b/tasks/vscode.yml
@@ -1,4 +1,17 @@
 ---
+- name: Import Microsoft GPG key for Visual Studio Code (Fedora)
+  ansible.builtin.rpm_key:
+    key: https://packages.microsoft.com/keys/microsoft.asc
+    state: present
+  when: target_os == 'fedora'
+
+- name: Configure Visual Studio Code repository (Fedora)
+  ansible.builtin.get_url:
+    url: https://packages.microsoft.com/yumrepos/vscode/config.repo
+    dest: /etc/yum.repos.d/vscode.repo
+    mode: "0644"
+  when: target_os == 'fedora'
+
 - name: Install Visual Studio Code
   ansible.builtin.package:
     name: "{{ vscode_packages }}"


### PR DESCRIPTION
## Summary
- import Microsoft's GPG key on Fedora hosts
- download the Visual Studio Code repo definition before installing the package

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db1e661d008332915c2f0f29bfd4f9