### PR TITLE
Add Fedora-specific Yazi installation logic

### DIFF
--- a/tasks/yazi.yml
+++ b/tasks/yazi.yml
@@ -1,6 +1,47 @@
 ---
+- name: Install Yazi terminal file manager on Fedora
+  when: ansible_distribution == 'Fedora'
+  block:
+    - name: Enable Yazi COPR repository
+      community.general.copr:
+        name: atim/yazi
+        state: enabled
+      become: true
+
+    - name: Install Yazi from COPR
+      ansible.builtin.package:
+        name: "{{ yazi_packages }}"
+        state: present
+        use: "{{ pkg_mgr }}"
+      become: true
+  rescue:
+    - name: Ensure Rust toolchain available for Yazi build
+      ansible.builtin.package:
+        name:
+          - cargo
+          - rust
+        state: present
+        use: "{{ pkg_mgr }}"
+      become: true
+
+    - name: Install Yazi via Cargo
+      ansible.builtin.command:
+        cmd: cargo install yazi-fm --locked
+        creates: "{{ home }}/.cargo/bin/yazi"
+      become: true
+      become_user: "{{ username }}"
+
+    - name: Make Yazi available system-wide
+      ansible.builtin.copy:
+        src: "{{ home }}/.cargo/bin/yazi"
+        dest: /usr/local/bin/yazi
+        mode: "0755"
+        remote_src: true
+      become: true
+
 - name: Install Yazi terminal file manager
   ansible.builtin.package:
     name: "{{ yazi_packages }}"
     state: present
     use: "{{ pkg_mgr }}"
+  when: ansible_distribution != 'Fedora'


### PR DESCRIPTION
## Summary
- enable the Yazi COPR repository when running on Fedora
- fall back to building Yazi with cargo and copy the binary into /usr/local/bin when the package install is unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db1e6a4cd88332b84e1a65c7b934d2