### PR TITLE
Add Zen Browser installation option

### DIFF
--- a/presets/ideapad_330.yml
+++ b/presets/ideapad_330.yml
@@ -55,6 +55,7 @@ install_rog_packages: false
 install_brave: true
 install_firefox: true
 install_chromium: true
+install_zen: false
 
 # Dotfiles
 dotfiles_repo: "https://github.com/PcKiLl3r/.dotfiles.git"

--- a/presets/thinkpad_t16_gen2.yml
+++ b/presets/thinkpad_t16_gen2.yml
@@ -55,6 +55,7 @@ install_rog_packages: false
 install_brave: true
 install_firefox: true
 install_chromium: true
+install_zen: false
 
 # Dotfiles
 dotfiles_repo: "https://github.com/PcKiLl3r/.dotfiles.git"

--- a/tasks/browsers.yml
+++ b/tasks/browsers.yml
@@ -22,3 +22,7 @@
     name: "{{ 'chromium-browser' if target_os == 'ubuntu' else 'chromium' }}"
     state: present
   when: install_chromium | default(false) | bool
+
+- name: Install Zen Browser
+  ansible.builtin.import_tasks: zen.yml
+  when: install_zen | default(false) | bool

--- a/tasks/zen.yml
+++ b/tasks/zen.yml
@@ -1,0 +1,77 @@
+---
+- name: Ensure Zen Browser is supported on this OS
+  ansible.builtin.assert:
+    that:
+      - target_os in ['fedora', 'arch']
+    fail_msg: "Zen Browser installation is only supported on Fedora or Arch systems."
+
+- name: Determine Zen Browser installation method
+  ansible.builtin.set_fact:
+    zen_install_method: "{{ 'rpm' if target_os == 'fedora' else 'appimage' }}"
+
+- name: Attempt Fedora RPM installation
+  block:
+    - name: Download Zen Browser RPM package
+      ansible.builtin.get_url:
+        url: "https://github.com/zen-browser/desktop/releases/latest/download/zen.x86_64.rpm"
+        dest: "/tmp/zen-browser.rpm"
+        mode: "0644"
+      when: zen_install_method == 'rpm'
+
+    - name: Install Zen Browser RPM package
+      ansible.builtin.dnf:
+        name: "/tmp/zen-browser.rpm"
+        state: present
+      when: zen_install_method == 'rpm'
+  rescue:
+    - name: Fallback to AppImage installation when RPM fails
+      ansible.builtin.set_fact:
+        zen_install_method: "appimage"
+  when: zen_install_method in ['rpm', 'appimage']
+
+- name: Install Zen Browser AppImage
+  when: zen_install_method == 'appimage'
+  block:
+    - name: Ensure Zen Browser AppImage directory exists
+      ansible.builtin.file:
+        path: "/opt/zen-browser"
+        state: directory
+        mode: "0755"
+
+    - name: Download Zen Browser AppImage
+      ansible.builtin.get_url:
+        url: "https://github.com/zen-browser/desktop/releases/latest/download/zen-x86_64.AppImage"
+        dest: "/opt/zen-browser/zen-browser.AppImage"
+        mode: "0755"
+
+- name: Define Zen Browser binary candidates
+  ansible.builtin.set_fact:
+    zen_binary_candidates: >-
+      {{ ['/opt/zen/zen', '/usr/bin/zen'] if zen_install_method == 'rpm' else ['/opt/zen-browser/zen-browser.AppImage'] }}
+
+- name: Inspect Zen Browser binary candidates
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  register: zen_candidate_stats
+  loop: "{{ zen_binary_candidates }}"
+
+- name: Select Zen Browser binary target
+  ansible.builtin.set_fact:
+    zen_binary_target: >-
+      {{ (zen_candidate_stats.results | selectattr('stat.exists') | map(attribute='item') | first) | default(zen_binary_candidates[0]) }}
+
+- name: Ensure zen binary symlink exists
+  ansible.builtin.file:
+    src: "{{ zen_binary_target }}"
+    dest: "/usr/local/bin/zen"
+    state: link
+    force: true
+  when: zen_candidate_stats.results | selectattr('stat.exists') | list | length > 0
+
+- name: Ensure zen-browser binary symlink exists
+  ansible.builtin.file:
+    src: "{{ zen_binary_target }}"
+    dest: "/usr/local/bin/zen-browser"
+    state: link
+    force: true
+  when: zen_candidate_stats.results | selectattr('stat.exists') | list | length > 0


### PR DESCRIPTION
## Summary
- add an `install_zen` flag to the Fedora-based presets so the browser can be toggled per host
- create a dedicated task file that installs Zen Browser via the Fedora RPM or falls back to the official AppImage when required
- import the new task from the browsers play so the binary is linked into the PATH when the flag is enabled

## Testing
- ansible-playbook --syntax-check main.yml *(fails: ansible-playbook not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db1e6cb7bc8332b0b9e37831d37174