### PR TITLE
Restore bluetooth pairing backups

### DIFF
--- a/docs/fresh-install.md
+++ b/docs/fresh-install.md
@@ -29,6 +29,8 @@ If auto‑detection fails, set `OS_OVERRIDE` to `arch` or `fedora` as shown abov
    ```bash
    ansible-vault edit vault/bluetooth.yml --vault-password-file .ansible_vault_pass
    ```
+5. (Optional) Copy any trusted device backups from `/var/lib/bluetooth` into `files/bluetooth/<inventory_hostname>/` so they ca
+n be restored during provisioning.
 
 ## 3. Apply the playbook
 

--- a/files/bluetooth/README.md
+++ b/files/bluetooth/README.md
@@ -1,0 +1,12 @@
+# Bluetooth Backup Directory
+
+Place machine-specific backups of `/var/lib/bluetooth` here so the playbook can restore trusted device pairings. Create a subdirectory matching the inventory hostname and copy the backed-up files into it, for example:
+
+```
+files/
+  bluetooth/
+    my-laptop/
+      <contents of /var/lib/bluetooth>
+```
+
+You can also store the backup in an encrypted vault instead of committing it to the repository.

--- a/main.yml
+++ b/main.yml
@@ -271,3 +271,9 @@
     # - name: Import machine preset overrides
     #   ansible.builtin.import_tasks:
     #     file: ./tasks/presets.yml
+
+  handlers:
+    - name: Restart bluetooth service
+      ansible.builtin.systemd:
+        name: bluetooth
+        state: restarted

--- a/tasks/bluetooth.yml
+++ b/tasks/bluetooth.yml
@@ -5,6 +5,27 @@
     state: present
     use: "{{ pkg_mgr }}"
 
+- name: Check for bluetooth pairing backup
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/files/bluetooth/{{ inventory_hostname }}"
+  register: bluetooth_backup
+  when: restore_bluetooth_backup | default(restore_last_ssh | default(false)) | bool
+  become: false
+
+- name: Restore bluetooth pairing data
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/files/bluetooth/{{ inventory_hostname }}/"
+    dest: /var/lib/bluetooth/
+    owner: root
+    group: root
+    mode: preserve
+  when:
+    - restore_bluetooth_backup | default(restore_last_ssh | default(false)) | bool
+    - bluetooth_backup is defined
+    - bluetooth_backup.stat.exists
+  notify: Restart bluetooth service
+  become: true
+
 - name: Enable and start bluetooth service
   ansible.builtin.systemd:
     name: bluetooth


### PR DESCRIPTION
## Summary
- document where to store `/var/lib/bluetooth` backups and add a repository location for them
- restore bluetooth pairing data when requested and restart the service only if data changes
- add a handler to restart bluetooth so restores reload pairing information

## Testing
- not run (ansible-playbook unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db1e6b2604833283a3a1e3319faae9