### PR TITLE
Configure npm prefix and install Angular CLI

### DIFF
--- a/tasks/prog-lang.yml
+++ b/tasks/prog-lang.yml
@@ -11,6 +11,43 @@
     state: present
     use: "{{ pkg_mgr }}"
 
+- name: Ensure npm global prefix directory exists
+  ansible.builtin.file:
+    path: "{{ home }}/.npm-global"
+    state: directory
+    mode: "0755"
+    owner: "{{ username }}"
+    group: "{{ username }}"
+
+- name: Configure npm to use the user prefix
+  ansible.builtin.lineinfile:
+    path: "{{ home }}/.npmrc"
+    regexp: "^prefix="
+    line: "prefix={{ home }}/.npm-global"
+    create: true
+    mode: "0644"
+  become: true
+  become_user: "{{ username }}"
+
+- name: Ensure npm global bin directory is on PATH
+  ansible.builtin.copy:
+    dest: /etc/profile.d/npm-global.sh
+    content: |
+      export PATH="{{ home }}/.npm-global/bin:$PATH"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Install Angular CLI globally
+  community.general.npm:
+    name: "@angular/cli"
+    global: true
+    state: present
+  environment:
+    NPM_CONFIG_PREFIX: "{{ home }}/.npm-global"
+  become: true
+  become_user: "{{ username }}"
+
 - name: Install C, C++ Development Tools
   ansible.builtin.package:
     name: "{{ prog_lang_cdev_packages }}"


### PR DESCRIPTION
## Summary
- ensure npm global installs go into a user-owned prefix and add it to PATH
- install the Angular CLI through the programming languages task with the configured prefix

## Testing
- not run (vault-protected configuration prevents running playbook in CI)


------
https://chatgpt.com/codex/tasks/task_e_68db1e6e07508332b270ae44e436450d