### PR TITLE
Add preset-controlled Vimium C browser policies

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -80,6 +80,11 @@
       ansible.builtin.import_tasks:
         file: ./tasks/browsers.yml
 
+    - name: Import Vimium C configuration
+      ansible.builtin.import_tasks:
+        file: ./tasks/vimium_c.yml
+      when: install_vimium_c | default(false) | bool
+
     - name: Import Codecs Install
       ansible.builtin.import_tasks:
         file: ./tasks/codecs.yml

--- a/presets/ideapad_330.yml
+++ b/presets/ideapad_330.yml
@@ -43,6 +43,7 @@ install_graphviz: false
 install_dia: false
 install_bluetooth: true
 install_codecs: true
+install_vimium_c: false
 
 # Hyprland specific - ENABLED
 add_input_group: true

--- a/presets/thinkpad_t16_gen2.yml
+++ b/presets/thinkpad_t16_gen2.yml
@@ -43,6 +43,7 @@ install_graphviz: false
 install_dia: false
 install_bluetooth: true
 install_codecs: true
+install_vimium_c: false
 
 # Hyprland specific
 add_input_group: true

--- a/tasks/vimium_c.yml
+++ b/tasks/vimium_c.yml
@@ -1,0 +1,91 @@
+---
+- name: Configure Vimium C for Chromium
+  become: true
+  when:
+    - install_vimium_c | default(false) | bool
+    - install_chromium | default(false) | bool
+  block:
+    - name: Ensure Chromium managed policy directory exists
+      ansible.builtin.file:
+        path: /etc/chromium/policies/managed
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Force install Vimium C in Chromium
+      ansible.builtin.copy:
+        dest: /etc/chromium/policies/managed/vimium_c.json
+        owner: root
+        group: root
+        mode: '0644'
+        content: |
+          {
+            "ExtensionInstallForcelist": [
+              "hfjbmagddngcpeloejdejnfgbamkjaeg;https://clients2.google.com/service/update2/crx"
+            ]
+          }
+
+- name: Configure Vimium C for Brave
+  become: true
+  when:
+    - install_vimium_c | default(false) | bool
+    - install_brave | default(false) | bool
+  block:
+    - name: Ensure Brave managed policy directory exists
+      ansible.builtin.file:
+        path: /etc/brave/policies/managed
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Force install Vimium C in Brave
+      ansible.builtin.copy:
+        dest: /etc/brave/policies/managed/vimium_c.json
+        owner: root
+        group: root
+        mode: '0644'
+        content: |
+          {
+            "ExtensionInstallForcelist": [
+              "hfjbmagddngcpeloejdejnfgbamkjaeg;https://clients2.google.com/service/update2/crx"
+            ]
+          }
+
+- name: Configure Vimium C for Firefox
+  become: true
+  when:
+    - install_vimium_c | default(false) | bool
+    - install_firefox | default(false) | bool
+  block:
+    - name: Ensure Firefox distribution extensions directory exists
+      ansible.builtin.file:
+        path: /usr/lib/firefox/distribution/extensions
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Download Vimium C for Firefox
+      ansible.builtin.get_url:
+        url: https://github.com/gdh1995/vimium-c/releases/latest/download/vimium_c-ff.xpi
+        dest: /usr/lib/firefox/distribution/extensions/vimium_c.xpi
+        mode: '0644'
+
+    - name: Register Vimium C via Firefox policies
+      ansible.builtin.copy:
+        dest: /usr/lib/firefox/distribution/policies.json
+        owner: root
+        group: root
+        mode: '0644'
+        content: |
+          {
+            "policies": {
+              "Extensions": {
+                "Install": [
+                  "/usr/lib/firefox/distribution/extensions/vimium_c.xpi"
+                ]
+              }
+            }
+          }


### PR DESCRIPTION
## Summary
- add an install_vimium_c flag to presets and gate the new automation on it
- create managed browser policies for Chromium and Brave that force-install Vimium C
- download the Vimium C Firefox XPI and register it through distribution policies

## Testing
- ⚠️ `ansible-playbook --syntax-check main.yml` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db1e6f2fa883329f3843f25e293874