### PR TITLE
Add Deno installer task for Neovim setups

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -104,6 +104,11 @@
       ansible.builtin.import_tasks:
         file: ./tasks/prog-lang.yml
 
+    - name: Import Deno Install
+      ansible.builtin.import_tasks:
+        file: ./tasks/deno.yml
+      when: "'neovim' in code_editors"
+
     - name: Import TMux Install
       ansible.builtin.import_tasks:
         file: ./tasks/tmux.yml

--- a/tasks/deno.yml
+++ b/tasks/deno.yml
@@ -1,0 +1,72 @@
+---
+- name: Download Deno installer script
+  ansible.builtin.get_url:
+    url: https://deno.land/install.sh
+    dest: /tmp/install_deno.sh
+    mode: '0755'
+
+- name: Run Deno installer
+  ansible.builtin.command: /bin/sh /tmp/install_deno.sh
+  args:
+    creates: "{{ home }}/.deno/bin/deno"
+  environment:
+    DENO_INSTALL: "{{ home }}/.deno"
+    HOME: "{{ home }}"
+  become: true
+  become_user: "{{ username }}"
+
+- name: Ensure Deno environment variables are exported in .profile
+  ansible.builtin.blockinfile:
+    path: "{{ home }}/.profile"
+    create: true
+    marker: "# {mark} ANSIBLE MANAGED BLOCK: deno"
+    block: |
+      export DENO_INSTALL="{{ home }}/.deno"
+      export PATH="$DENO_INSTALL/bin:$PATH"
+  become: true
+  become_user: "{{ username }}"
+
+- name: Ensure Deno environment variables are exported in .zprofile
+  ansible.builtin.blockinfile:
+    path: "{{ home }}/.zprofile"
+    create: true
+    marker: "# {mark} ANSIBLE MANAGED BLOCK: deno"
+    block: |
+      export DENO_INSTALL="{{ home }}/.deno"
+      export PATH="$DENO_INSTALL/bin:$PATH"
+  become: true
+  become_user: "{{ username }}"
+  when: (shell | default('')) == 'zsh'
+
+- name: Ensure Deno environment variables are exported in .bashrc
+  ansible.builtin.blockinfile:
+    path: "{{ home }}/.bashrc"
+    create: true
+    marker: "# {mark} ANSIBLE MANAGED BLOCK: deno"
+    block: |
+      export DENO_INSTALL="{{ home }}/.deno"
+      export PATH="$DENO_INSTALL/bin:$PATH"
+  become: true
+  become_user: "{{ username }}"
+  when: (shell | default('')) == 'bash'
+
+- name: Ensure fish configuration directory exists
+  ansible.builtin.file:
+    path: "{{ home }}/.config/fish"
+    state: directory
+    mode: '0755'
+  become: true
+  become_user: "{{ username }}"
+  when: (shell | default('')) == 'fish'
+
+- name: Ensure Deno environment variables are exported in fish config
+  ansible.builtin.blockinfile:
+    path: "{{ home }}/.config/fish/config.fish"
+    create: true
+    marker: "# {mark} ANSIBLE MANAGED BLOCK: deno"
+    block: |
+      set -x DENO_INSTALL "{{ home }}/.deno"
+      set -gx PATH $DENO_INSTALL/bin $PATH
+  become: true
+  become_user: "{{ username }}"
+  when: (shell | default('')) == 'fish'


### PR DESCRIPTION
## Summary
- add a dedicated Deno installation task that runs the official installer and configures shell profiles
- import the Deno task from the main playbook whenever Neovim is part of the requested editors

## Testing
- `ansible-playbook main.yml --syntax-check` *(fails: ansible-playbook not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db1e7046548332a9d32a21e1e773ef