### PR TITLE
Replace Chromium support with Zen browser across presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Available presets:
 - `thinkpad_t16_gen2.yml` - ThinkPad T16 Gen 2 with Hyprland
 - `ideapad_330.yml` - Ideapad 330 with i3
 
+## Browser Lineup
+
+The playbook can install the following browsers via `tasks/browsers.yml`:
+
+- Brave (default on most presets)
+- Firefox
+- Zen Browser (Chromium replacement)
+
 ## Adding a New Machine
 
 1. **Copy existing preset:**

--- a/docs/fresh-install.md
+++ b/docs/fresh-install.md
@@ -19,7 +19,7 @@ If auto‑detection fails, set `OS_OVERRIDE` to `arch` or `fedora` as shown abov
    cd ~/personal/linux-dev-playbook
    cp config.template.yml config.yml
    ```
-2. Edit `config.yml` and set the `machine_preset` to match the current machine. Available presets live under `resources/presets/` (e.g. `thinkpad_t16_gen2`, `ideapad_330`, `4k`).
+2. Edit `config.yml` and set the `machine_preset` to match the current machine. Available presets live under `resources/presets/` (e.g. `thinkpad_t16_gen2`, `ideapad_330`, `4k`). Review the browser flags in the chosen preset to enable any of the supported options (Brave, Firefox, or Zen Browser).
 3. Create a file named `.ansible_vault_pass` containing your Ansible Vault passphrase:
    ```bash
    echo 'your‑vault‑password' > .ansible_vault_pass

--- a/presets/ideapad_330.yml
+++ b/presets/ideapad_330.yml
@@ -54,8 +54,7 @@ install_rog_packages: false
 # Browsers
 install_brave: true
 install_firefox: true
-install_chromium: true
-install_zen: false
+install_zen: true
 
 # Dotfiles
 dotfiles_repo: "https://github.com/PcKiLl3r/.dotfiles.git"

--- a/presets/thinkpad_t16_gen2.yml
+++ b/presets/thinkpad_t16_gen2.yml
@@ -55,8 +55,7 @@ install_rog_packages: false
 # Browsers
 install_brave: true
 install_firefox: true
-install_chromium: true
-install_zen: false
+install_zen: true
 
 # Dotfiles
 dotfiles_repo: "https://github.com/PcKiLl3r/.dotfiles.git"

--- a/tasks/browsers.yml
+++ b/tasks/browsers.yml
@@ -17,12 +17,6 @@
     state: present
   when: install_firefox | bool
 
-- name: Install Chromium browser
-  ansible.builtin.package:
-    name: "{{ 'chromium-browser' if target_os == 'ubuntu' else 'chromium' }}"
-    state: present
-  when: install_chromium | default(false) | bool
-
 - name: Install Zen Browser
   ansible.builtin.import_tasks: zen.yml
   when: install_zen | default(false) | bool


### PR DESCRIPTION
## Summary
- remove the Chromium installation task from the browser role
- update presets to drop the install_chromium flag and enable Zen where applicable
- document the supported browser lineup in the README and fresh install guide

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de8aaac30c8332af4b2658110e47ec