### PR TITLE
Add Docker Desktop automation for Fedora and Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,18 @@ make lint
 
 - Fedora or Arch-based Linux
 - Ansible and git (installed by setup script)
+- Optional Docker Desktop support requires:
+  - Hardware virtualization enabled in firmware (VT-x/AMD-V)
+  - Systemd user lingering for the target user (handled by the playbook)
+  - Network access to download packages from Docker
+
+## Docker Desktop (optional)
+
+Set `install_docker_desktop: true` in your preset to have the playbook:
+
+- Add the official Docker repositories (Fedora) and dependencies
+- Download and install the latest Docker Desktop package for Fedora or Arch
+- Enable both the system and user systemd services for Docker Desktop
+- Verify the installation with `docker version` and `com.docker.cli -v`
 
 That's it. No config files, no templates, no duplication.

--- a/presets/ideapad_330.yml
+++ b/presets/ideapad_330.yml
@@ -43,6 +43,7 @@ install_graphviz: false
 install_dia: false
 install_bluetooth: true
 install_codecs: true
+install_docker_desktop: false
 
 # Hyprland specific - ENABLED
 add_input_group: true

--- a/presets/thinkpad_t16_gen2.yml
+++ b/presets/thinkpad_t16_gen2.yml
@@ -44,6 +44,7 @@ install_dia: false
 install_bluetooth: true
 install_codecs: true
 install_intel_wifi_firmware: true
+install_docker_desktop: false
 
 # Hyprland specific
 add_input_group: true

--- a/tasks/dev-tools.yml
+++ b/tasks/dev-tools.yml
@@ -5,11 +5,141 @@
     state: present
     use: "{{ pkg_mgr }}"
 
+- name: Create temporary directory for Docker Desktop package
+  ansible.builtin.tempfile:
+    state: directory
+    prefix: docker-desktop-
+  register: docker_desktop_tmpdir
+  when: install_docker_desktop | bool
+
+- name: Configure Docker CE repository for Docker Desktop
+  ansible.builtin.yum_repository:
+    name: "{{ docker_desktop_repo_name }}"
+    description: Docker CE Stable - $releasever
+    baseurl: https://download.docker.com/linux/fedora/$releasever/$basearch/stable
+    gpgcheck: true
+    gpgkey: https://download.docker.com/linux/fedora/gpg
+    enabled: true
+  when:
+    - install_docker_desktop | bool
+    - target_os == 'fedora'
+
+- name: Install Docker Desktop dependencies
+  ansible.builtin.package:
+    name: "{{ docker_desktop_dependencies }}"
+    state: present
+    use: "{{ pkg_mgr }}"
+  when:
+    - install_docker_desktop | bool
+    - target_os in ['fedora', 'arch']
+
+- name: Download Docker Desktop package
+  ansible.builtin.get_url:
+    url: "{{ docker_desktop_package_url }}"
+    dest: "{{ docker_desktop_tmpdir.path }}/{{ docker_desktop_package_filename }}"
+    mode: "0644"
+    headers:
+      User-Agent: curl/7.88.1
+  when:
+    - install_docker_desktop | bool
+    - target_os in ['fedora', 'arch']
+
+- name: Install Docker Desktop package on Fedora
+  ansible.builtin.dnf:
+    name: "{{ docker_desktop_tmpdir.path }}/{{ docker_desktop_package_filename }}"
+    state: present
+  when:
+    - install_docker_desktop | bool
+    - target_os == 'fedora'
+
+- name: Install Docker Desktop package on Arch
+  ansible.builtin.pacman:
+    name: "{{ docker_desktop_tmpdir.path }}/{{ docker_desktop_package_filename }}"
+    state: present
+  when:
+    - install_docker_desktop | bool
+    - target_os == 'arch'
+
+- name: Ensure Docker service is enabled and running
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    enabled: true
+    state: started
+  loop:
+    - docker.service
+    - docker.socket
+  when:
+    - install_docker_desktop | bool
+    - target_os in ['fedora', 'arch']
+
+- name: Check lingering status for {{ username }}
+  ansible.builtin.command: "loginctl show-user {{ username }}"
+  register: docker_desktop_linger_status
+  changed_when: false
+  when:
+    - install_docker_desktop | bool
+    - target_os in ['fedora', 'arch']
+
+- name: Enable lingering for {{ username }}
+  ansible.builtin.command: "loginctl enable-linger {{ username }}"
+  when:
+    - install_docker_desktop | bool
+    - target_os in ['fedora', 'arch']
+    - docker_desktop_linger_status.stdout is search('Linger=no')
+
+- name: Get UID for {{ username }}
+  ansible.builtin.command: "id -u {{ username }}"
+  register: docker_desktop_uid
+  changed_when: false
+  when:
+    - install_docker_desktop | bool
+    - target_os in ['fedora', 'arch']
+
+- name: Ensure Docker Desktop user services are enabled and running
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    scope: user
+    enabled: true
+    state: started
+  loop:
+    - docker-desktop
+    - docker-desktop-proxy
+  become: true
+  become_user: "{{ username }}"
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ docker_desktop_uid.stdout }}"
+    DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ docker_desktop_uid.stdout }}/bus"
+  when:
+    - install_docker_desktop | bool
+    - target_os in ['fedora', 'arch']
+
 - name: Verify Docker installation
   ansible.builtin.command: docker --version
   register: docker_check
   changed_when: false
   failed_when: docker_check.rc != 0
+
+- name: Verify Docker daemon availability
+  ansible.builtin.command: docker version
+  register: docker_daemon_check
+  become: true
+  become_user: "{{ username }}"
+  changed_when: false
+  failed_when: docker_daemon_check.rc != 0
+  when:
+    - install_docker_desktop | bool
+    - target_os in ['fedora', 'arch']
+
+- name: Verify Docker Desktop CLI availability
+  ansible.builtin.command: com.docker.cli -v
+  register: docker_desktop_cli_check
+  become: true
+  become_user: "{{ username }}"
+  changed_when: false
+  failed_when: docker_desktop_cli_check.rc != 0
+  when:
+    - install_docker_desktop | bool
+    - target_os in ['fedora', 'arch']
 
 - name: Ensure Group "docker" Exists with correct gid
   ansible.builtin.group:

--- a/vars/arch.yml
+++ b/vars/arch.yml
@@ -149,6 +149,13 @@ dev_tools_packages:
   - docker-compose
   - python-pip
 
+docker_desktop_package_filename: docker-desktop-latest-x86_64.pkg.tar.zst
+docker_desktop_package_url: https://desktop.docker.com/linux/main/arch/x86_64/docker-desktop-latest-x86_64.pkg.tar.zst
+docker_desktop_dependencies:
+  - docker
+  - docker-compose
+  - fuse-overlayfs
+
 neovim_dependencies_packages:
   - cmake
   - gettext

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -149,6 +149,15 @@ dev_tools_packages:
   - docker-compose
   - python3-pip
 
+docker_desktop_package_filename: docker-desktop-latest.x86_64.rpm
+docker_desktop_package_url: https://desktop.docker.com/linux/main/amd64/docker-desktop-latest.x86_64.rpm
+docker_desktop_dependencies:
+  - dnf-plugins-core
+  - docker-ce-cli
+  - containerd.io
+  - docker-compose-plugin
+docker_desktop_repo_name: docker-ce-stable
+
 neovim_dependencies_packages:
   - cmake
   - gettext


### PR DESCRIPTION
## Summary
- add an `install_docker_desktop` toggle to presets and document the prerequisites in the README
- download the official Docker Desktop packages for Fedora and Arch along with required repositories and dependencies
- enable Docker Desktop services, adjust lingering, and verify the installation with CLI checks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de8aabb9e88332866c9005e37cc05c