### PR TITLE
Add Mattermost support and enforce accessibility browser extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ The playbook can install the following browsers via `tasks/browsers.yml`:
 - Zen Browser (Chromium replacement)
 - Google Chrome (Fedora or Debian/Ubuntu targets)
 
+Chrome installs automatically ship with the WAVE Evaluation Tool and Vimium C extensions enabled via managed policies. Brave and Firefox deployments also receive Vimium C so keyboard navigation is consistent across browsers.
+
 ## Application toggles
 
 Presets enable the GUI applications you want via boolean flags. Set a flag to `true` or `false` directly in the preset (or an override file) to opt in or out of an application.
@@ -68,6 +70,7 @@ Presets enable the GUI applications you want via boolean flags. Set a flag to `t
 | `install_spotify` | Install Spotify from Flathub (system-wide) and add a `/usr/local/bin/spotify` launcher. |
 | `install_obsidian` | Install Obsidian from Flathub and add a `/usr/local/bin/obsidian` launcher. |
 | `install_chatgpt_desktop` | Install the ChatGPT Desktop Flatpak and add a `/usr/local/bin/chatgpt-desktop` launcher. |
+| `install_mattermost` | Install the Mattermost desktop client from Flathub and add a `/usr/local/bin/mattermost` launcher. |
 | `install_pgmodeler` | Install pgModeler from the native package repositories. |
 | `install_zen` | Install Zen Browser (RPM on Fedora, AppImage fallback on Arch) and provide `/usr/local/bin/zen`. |
 | `install_chrome` | Install Google Chrome from the official repositories (Fedora) or direct Debian package (Debian/Ubuntu). |

--- a/presets/ideapad_330.yml
+++ b/presets/ideapad_330.yml
@@ -33,7 +33,7 @@ ai_tool: "none"
 # Install flags
 install_gimp: false
 install_inkscape: false
-install_libreoffice: false
+install_libreoffice: true
 install_audacity: false
 install_qalculate: false
 install_calcurse: false
@@ -47,6 +47,7 @@ install_docker_desktop: false
 install_spotify: true
 install_obsidian: true
 install_chatgpt_desktop: true
+install_mattermost: true
 
 # Hyprland specific - ENABLED
 add_input_group: true

--- a/presets/thinkpad_t16_gen2.yml
+++ b/presets/thinkpad_t16_gen2.yml
@@ -33,7 +33,7 @@ ai_tool: "none"
 # Install flags
 install_gimp: false
 install_inkscape: false
-install_libreoffice: false
+install_libreoffice: true
 install_audacity: false
 install_qalculate: false
 install_calcurse: false
@@ -46,6 +46,7 @@ install_codecs: true
 install_spotify: true
 install_obsidian: true
 install_chatgpt_desktop: true
+install_mattermost: true
 install_intel_wifi_firmware: true
 install_docker_desktop: false
 

--- a/tasks/browsers.yml
+++ b/tasks/browsers.yml
@@ -11,10 +11,52 @@
   failed_when: brave_check.rc != 0
   when: install_brave | bool and target_os in ['debian', 'ubuntu']
 
+- name: Ensure Brave managed policies directory exists
+  ansible.builtin.file:
+    path: /etc/opt/brave/policies/managed
+    state: directory
+    mode: '0755'
+  when: install_brave | bool and target_os in ['debian', 'ubuntu']
+
+- name: Configure Brave mandatory extensions
+  ansible.builtin.copy:
+    dest: /etc/opt/brave/policies/managed/extensions.json
+    mode: '0644'
+    content: |
+      {
+        "ExtensionInstallForcelist": [
+          "{{ vimium_c_extension_chrome_id }};{{ chrome_extension_update_url }}"
+        ]
+      }
+  when: install_brave | bool and target_os in ['debian', 'ubuntu']
+
 - name: Install Firefox browser
   ansible.builtin.package:
     name: firefox
     state: present
+  when: install_firefox | bool
+
+- name: Ensure Firefox policies directory exists
+  ansible.builtin.file:
+    path: /etc/firefox/policies
+    state: directory
+    mode: '0755'
+  when: install_firefox | bool
+
+- name: Configure Firefox mandatory extensions
+  ansible.builtin.copy:
+    dest: /etc/firefox/policies/policies.json
+    mode: '0644'
+    content: |
+      {
+        "policies": {
+          "Extensions": {
+            "Install": [
+              "{{ vimium_c_firefox_addon_url }}"
+            ]
+          }
+        }
+      }
   when: install_firefox | bool
 
 - name: Install Google Chrome browser
@@ -66,6 +108,24 @@
       register: chrome_check
       changed_when: false
       failed_when: chrome_check.rc != 0
+
+    - name: Ensure Google Chrome managed policies directory exists
+      ansible.builtin.file:
+        path: /etc/opt/chrome/policies/managed
+        state: directory
+        mode: '0755'
+
+    - name: Configure Google Chrome mandatory extensions
+      ansible.builtin.copy:
+        dest: /etc/opt/chrome/policies/managed/extensions.json
+        mode: '0644'
+        content: |
+          {
+            "ExtensionInstallForcelist": [
+              "{{ wave_extension_chrome_id }};{{ chrome_extension_update_url }}",
+              "{{ vimium_c_extension_chrome_id }};{{ chrome_extension_update_url }}"
+            ]
+          }
 
 - name: Install Zen Browser
   ansible.builtin.import_tasks: zen.yml

--- a/tasks/gui-software.yml
+++ b/tasks/gui-software.yml
@@ -10,7 +10,8 @@
     gui_flatpak_requested: >-
       {{ (install_spotify | default(false) | bool)
          or (install_obsidian | default(false) | bool)
-         or (install_chatgpt_desktop | default(false) | bool) }}
+         or (install_chatgpt_desktop | default(false) | bool)
+         or (install_mattermost | default(false) | bool) }}
 
 - name: Ensure Flatpak is installed
   ansible.builtin.package:
@@ -107,6 +108,23 @@
       #!/usr/bin/env bash
       exec flatpak run {{ chatgpt_desktop_flatpak_id }} "$@"
   when: install_chatgpt_desktop | default(false) | bool
+
+- name: Install Mattermost via Flatpak
+  community.general.flatpak:
+    name: "{{ mattermost_flatpak_id }}"
+    state: present
+  when: install_mattermost | default(false) | bool
+
+- name: Ensure mattermost launcher script is present
+  ansible.builtin.copy:
+    dest: /usr/local/bin/mattermost
+    mode: '0755'
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      exec flatpak run {{ mattermost_flatpak_id }} "$@"
+  when: install_mattermost | default(false) | bool
 
 - name: Ensure dependency for brave installer is present
   ansible.builtin.package:

--- a/vars/arch.yml
+++ b/vars/arch.yml
@@ -196,6 +196,12 @@ flatpak_remote_url: https://flathub.org/repo/flathub.flatpakrepo
 spotify_flatpak_id: com.spotify.Client
 obsidian_flatpak_id: md.obsidian.Obsidian
 chatgpt_desktop_flatpak_id: io.github.gi_lom.ChatGPTDesktop
+mattermost_flatpak_id: com.mattermost.Desktop
+
+chrome_extension_update_url: https://clients2.google.com/service/update2/crx
+wave_extension_chrome_id: jbbplnpkjmmeebjpijfedlgcdilocofh
+vimium_c_extension_chrome_id: hfjbmagddngcpeloejdejnfgbamkjaeg
+vimium_c_firefox_addon_url: https://addons.mozilla.org/firefox/downloads/latest/vimium-c/latest.xpi
 
 brave_dependency_packages:
   - acl

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -198,6 +198,12 @@ flatpak_remote_url: https://flathub.org/repo/flathub.flatpakrepo
 spotify_flatpak_id: com.spotify.Client
 obsidian_flatpak_id: md.obsidian.Obsidian
 chatgpt_desktop_flatpak_id: io.github.gi_lom.ChatGPTDesktop
+mattermost_flatpak_id: com.mattermost.Desktop
+
+chrome_extension_update_url: https://clients2.google.com/service/update2/crx
+wave_extension_chrome_id: jbbplnpkjmmeebjpijfedlgcdilocofh
+vimium_c_extension_chrome_id: hfjbmagddngcpeloejdejnfgbamkjaeg
+vimium_c_firefox_addon_url: https://addons.mozilla.org/firefox/downloads/latest/vimium-c/latest.xpi
 
 brave_dependency_packages:
   - acl


### PR DESCRIPTION
## Summary
- add Mattermost Flatpak installation support with presets defaulting to enable it alongside LibreOffice
- enforce accessibility-focused browser extensions by default, forcing WAVE on Chrome and Vimium C on Chrome, Brave, and Firefox
- document the new toggles and browser behavior in the README

## Testing
- not run (ansible-playbook not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3dfe176bc83329d5daa3cf82ebb9c