### PR TITLE
Ensure Postman installation directory exists before unarchive

### DIFF
--- a/tasks/gui-software.yml
+++ b/tasks/gui-software.yml
@@ -160,6 +160,12 @@
     dest: /tmp/postman.tar.gz
     mode: '0644'
 
+- name: Ensure Postman installation directory exists
+  ansible.builtin.file:
+    path: /opt/postman
+    state: directory
+    mode: '0755'
+
 - name: Install Postman
   ansible.builtin.unarchive:
     src: /tmp/postman.tar.gz


### PR DESCRIPTION
## Summary
- ensure the Postman installation directory is created before extracting the archive to avoid installation failures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3ec99ef6483328b1780c91b11ad58