### PR TITLE
Install Mattermost via native packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Presets enable the GUI applications you want via boolean flags. Set a flag to `t
 | `install_spotify` | Install Spotify from Flathub (system-wide) and add a `/usr/local/bin/spotify` launcher. |
 | `install_obsidian` | Install Obsidian from Flathub and add a `/usr/local/bin/obsidian` launcher. |
 | `install_chatgpt_desktop` | Install the ChatGPT Desktop Flatpak and add a `/usr/local/bin/chatgpt-desktop` launcher. |
-| `install_mattermost` | Install the Mattermost desktop client from Flathub and add a `/usr/local/bin/mattermost` launcher. |
+| `install_mattermost` | Install the Mattermost desktop client using the native package manager and add a `/usr/local/bin/mattermost` launcher. |
 | `install_pgmodeler` | Install pgModeler from the native package repositories. |
 | `install_zen` | Install Zen Browser (RPM on Fedora, AppImage fallback on Arch) and provide `/usr/local/bin/zen`. |
 | `install_chrome` | Install Google Chrome from the official repositories (Fedora) or direct Debian package (Debian/Ubuntu). |

--- a/tasks/gui-software.yml
+++ b/tasks/gui-software.yml
@@ -5,13 +5,19 @@
     state: present
     use: "{{ pkg_mgr }}"
 
+- name: Determine Mattermost install method
+  ansible.builtin.set_fact:
+    mattermost_install_method: "{{ mattermost_install_method_override | default('package' if target_os in ['arch', 'fedora'] else 'flatpak') }}"
+  when: install_mattermost | default(false) | bool
+
 - name: Determine whether Flatpak applications are requested
   ansible.builtin.set_fact:
     gui_flatpak_requested: >-
       {{ (install_spotify | default(false) | bool)
          or (install_obsidian | default(false) | bool)
          or (install_chatgpt_desktop | default(false) | bool)
-         or (install_mattermost | default(false) | bool) }}
+         or (install_mattermost | default(false) | bool
+             and (mattermost_install_method | default('flatpak')) == 'flatpak') }}
 
 - name: Ensure Flatpak is installed
   ansible.builtin.package:
@@ -113,6 +119,57 @@
   community.general.flatpak:
     name: "{{ mattermost_flatpak_id }}"
     state: present
+  when:
+    - install_mattermost | default(false) | bool
+    - (mattermost_install_method | default('flatpak')) == 'flatpak'
+
+- name: Install Mattermost Desktop via package manager
+  ansible.builtin.package:
+    name: "{{ mattermost_package_name }}"
+    state: present
+    use: "{{ pkg_mgr }}"
+  when:
+    - install_mattermost | default(false) | bool
+    - (mattermost_install_method | default('flatpak')) == 'package'
+    - target_os == 'arch'
+
+- name: Ensure Mattermost Desktop repository GPG key is installed
+  ansible.builtin.rpm_key:
+    key: "{{ mattermost_rpm_gpg_key_url }}"
+    state: present
+  when:
+    - install_mattermost | default(false) | bool
+    - (mattermost_install_method | default('flatpak')) == 'package'
+    - target_os == 'fedora'
+
+- name: Ensure Mattermost Desktop repository is configured
+  ansible.builtin.yum_repository:
+    name: mattermost-desktop
+    description: Mattermost Desktop
+    baseurl: "{{ mattermost_rpm_baseurl }}"
+    enabled: true
+    gpgcheck: true
+    repo_gpgcheck: true
+    gpgkey: "{{ mattermost_rpm_gpg_key_url }}"
+  when:
+    - install_mattermost | default(false) | bool
+    - (mattermost_install_method | default('flatpak')) == 'package'
+    - target_os == 'fedora'
+
+- name: Install Mattermost Desktop via DNF
+  ansible.builtin.package:
+    name: "{{ mattermost_package_name }}"
+    state: present
+    use: "{{ pkg_mgr }}"
+  when:
+    - install_mattermost | default(false) | bool
+    - (mattermost_install_method | default('flatpak')) == 'package'
+    - target_os == 'fedora'
+
+- name: Determine Mattermost launcher command
+  ansible.builtin.set_fact:
+    mattermost_launcher_command: >-
+      {{ 'flatpak run ' ~ mattermost_flatpak_id if (mattermost_install_method | default('flatpak')) == 'flatpak' else mattermost_package_launcher }}
   when: install_mattermost | default(false) | bool
 
 - name: Ensure mattermost launcher script is present
@@ -123,7 +180,7 @@
     group: root
     content: |
       #!/usr/bin/env bash
-      exec flatpak run {{ mattermost_flatpak_id }} "$@"
+      exec {{ mattermost_launcher_command }} "$@"
   when: install_mattermost | default(false) | bool
 
 - name: Ensure dependency for brave installer is present

--- a/vars/arch.yml
+++ b/vars/arch.yml
@@ -197,6 +197,8 @@ spotify_flatpak_id: com.spotify.Client
 obsidian_flatpak_id: md.obsidian.Obsidian
 chatgpt_desktop_flatpak_id: io.github.lencx.ChatGPT
 mattermost_flatpak_id: com.mattermost.Desktop
+mattermost_package_name: mattermost-desktop
+mattermost_package_launcher: mattermost-desktop
 
 chrome_extension_update_url: https://clients2.google.com/service/update2/crx
 wave_extension_chrome_id: jbbplnpkjmmeebjpijfedlgcdilocofh

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -199,6 +199,10 @@ spotify_flatpak_id: com.spotify.Client
 obsidian_flatpak_id: md.obsidian.Obsidian
 chatgpt_desktop_flatpak_id: io.github.lencx.ChatGPT
 mattermost_flatpak_id: com.mattermost.Desktop
+mattermost_package_name: mattermost-desktop
+mattermost_package_launcher: mattermost-desktop
+mattermost_rpm_gpg_key_url: https://rpm.packages.mattermost.com/pubkey.gpg
+mattermost_rpm_baseurl: https://rpm.packages.mattermost.com/$releasever/$basearch
 
 chrome_extension_update_url: https://clients2.google.com/service/update2/crx
 wave_extension_chrome_id: jbbplnpkjmmeebjpijfedlgcdilocofh


### PR DESCRIPTION
## Summary
- choose the package-manager installation method for Mattermost on supported Fedora and Arch targets, falling back to Flatpak only when requested
- configure the Mattermost RPM repository on Fedora targets and install the desktop client through dnf
- keep the launcher script working for both Flatpak and native package installs while updating documentation

## Testing
- `ansible-playbook --syntax-check main.yml` *(fails: ansible-playbook not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f1ebd3288332b69214bb2ea376d6