### PR TITLE
Add OpenVPN to utility package installs

### DIFF
--- a/vars/arch.yml
+++ b/vars/arch.yml
@@ -46,6 +46,7 @@ utils_packages:
   - tldr
   - shutter
   - trash-cli
+  - openvpn
 
 virtualization_kernel_deps_packages:
   - base-devel

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -41,6 +41,7 @@ utils_packages:
   - tldr
   - shutter
   - trash-cli
+  - openvpn
   - NetworkManager-tui
 
 install_networkmanager_tui: true


### PR DESCRIPTION
## Summary
- include OpenVPN in the Fedora and Arch utility package lists so it is installed by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e40819e764833297186ce170b05793