### PR TITLE
Fix Neovim provider health check prerequisites

### DIFF
--- a/tasks/neovim.yml
+++ b/tasks/neovim.yml
@@ -23,6 +23,13 @@
     state: present
     use: "{{ pkg_mgr }}"
 
+- name: Install Lua 5.1 compatibility packages for NeoVim
+  ansible.builtin.package:
+    name: "{{ neovim_lua_compat_packages | default([]) }}"
+    state: present
+    use: "{{ pkg_mgr }}"
+  when: (neovim_lua_compat_packages | default([])) | length > 0
+
 - name: Plenary
   ansible.builtin.git:
     repo: "https://github.com/nvim-lua/plenary.nvim.git"
@@ -68,6 +75,14 @@
 - name: Install Stylua
   ansible.builtin.command: cargo install stylua
   changed_when: false
+  become: true
+  become_user: "{{ username }}"
+
+- name: Install pynvim for Python provider
+  ansible.builtin.pip:
+    name: pynvim
+    extra_args: --user
+    executable: pip3
   become: true
   become_user: "{{ username }}"
 

--- a/tasks/nodejs.yml
+++ b/tasks/nodejs.yml
@@ -5,6 +5,18 @@
     state: present
   become: no
 
+- name: Install global JavaScript tooling
+  npm:
+    name: "{{ item }}"
+    global: yes
+    state: present
+  become: no
+  loop:
+    - prettier
+    - "@fsouza/prettierd"
+    - tree-sitter-cli
+    - neovim
+
 # - name: Install Angular CLI via npm command
 #   shell: npm install -g @angular/cli
 #   args:

--- a/tasks/tmux.yml
+++ b/tasks/tmux.yml
@@ -4,3 +4,21 @@
     name: "{{ tmux_packages }}"
     state: present
     use: "{{ pkg_mgr }}"
+
+- name: Enable tmux focus events
+  ansible.builtin.lineinfile:
+    path: "/home/{{ username }}/.tmux.conf"
+    regexp: "^set-option -g focus-events"
+    line: "set-option -g focus-events on"
+    create: true
+  become: true
+  become_user: "{{ username }}"
+
+- name: Enable true color support in tmux
+  ansible.builtin.lineinfile:
+    path: "/home/{{ username }}/.tmux.conf"
+    regexp: "^set-option -a terminal-features"
+    line: "set-option -a terminal-features 'screen-256color:RGB'"
+    create: true
+  become: true
+  become_user: "{{ username }}"

--- a/vars/arch.yml
+++ b/vars/arch.yml
@@ -47,6 +47,7 @@ utils_packages:
   - shutter
   - trash-cli
   - openvpn
+  - fd
 
 virtualization_kernel_deps_packages:
   - base-devel
@@ -182,6 +183,8 @@ neovim_rust_packages:
 
 neovim_luarocks_package:
   - luarocks
+
+neovim_lua_compat_packages: []
 
 gui_dependencies_packages:
   - base-devel

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -43,6 +43,7 @@ utils_packages:
   - trash-cli
   - openvpn
   - NetworkManager-tui
+  - fd-find
 
 install_networkmanager_tui: true
 
@@ -177,6 +178,10 @@ neovim_dependencies_packages:
   - libevent
   - readline
   - ncurses
+
+neovim_lua_compat_packages:
+  - lua5.1
+  - lua5.1-devel
 
 neovim_rust_packages:
   - rust


### PR DESCRIPTION
## Summary
- install the fd utility and Lua 5.1 compatibility packages needed by Neovim health checks
- provision pynvim, neovim, prettier, prettierd, and tree-sitter CLI for editor providers
- configure tmux to emit focus events and enable true color by default

## Testing
- not run (ansible-playbook not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e68cdb268083329b252f92643e721e