### PR TITLE
Switch Fedora Spotify provisioning to RPM Fusion LPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Presets enable the GUI applications you want via boolean flags. Set a flag to `t
 
 | Flag | Description |
 | --- | --- |
-| `install_spotify` | Install Spotify via native packages (negativo17 on Fedora, community repo on Arch) and ensure the Flatpak wrapper is removed. |
+| `install_spotify` | Install Spotify via native packages (RPM Fusion + LPF workflow on Fedora, community repo on Arch) and ensure the Flatpak wrapper is removed. |
 | `install_obsidian` | Install Obsidian from the official repositories (RPM on Fedora, community package on Arch) and remove the legacy Flatpak wrapper. |
 | `install_chatgpt_desktop` | Download the ChatGPT Desktop AppImage and install a `/usr/local/bin/chatgpt-desktop` wrapper. |
 | `install_mattermost` | Install the Mattermost desktop client from Flathub and add a `/usr/local/bin/mattermost` launcher. |

--- a/docs/fresh-install.md
+++ b/docs/fresh-install.md
@@ -36,7 +36,7 @@ n be restored during provisioning.
 
 Each preset exposes boolean flags that control optional GUI software. Set any of these to `false` if you want to skip an app (or `true` to ensure it is installed):
 
-- `install_spotify` – installs Spotify via the native package repositories (negativo17 on Fedora, community package on Arch) and removes the legacy Flatpak wrapper.
+- `install_spotify` – installs Spotify via the native package repositories (RPM Fusion + LPF workflow on Fedora, community package on Arch) and removes the legacy Flatpak wrapper.
 - `install_obsidian` – installs Obsidian from the official repositories (RPM on Fedora, community package on Arch) and removes the legacy Flatpak wrapper.
 - `install_chatgpt_desktop` – downloads the ChatGPT Desktop AppImage and exposes it through `/usr/local/bin/chatgpt-desktop`.
 - `install_mattermost` – installs the Mattermost desktop client from Flathub and exposes it through `/usr/local/bin/mattermost`.

--- a/tasks/gui-software.yml
+++ b/tasks/gui-software.yml
@@ -55,32 +55,60 @@
     flatpakrepo_url: "{{ flatpak_remote_url | default('https://flathub.org/repo/flathub.flatpakrepo') }}"
   when: gui_flatpak_requested | bool
 
-- name: Ensure Spotify repository GPG key is installed (Fedora)
-  ansible.builtin.rpm_key:
-    key: "{{ spotify_repo_gpgkey }}"
+- name: Ensure Spotify LPF wrapper is installed (Fedora)
+  ansible.builtin.package:
+    name: "{{ spotify_lpf_wrapper_package }}"
     state: present
+    use: "{{ pkg_mgr }}"
   when:
     - install_spotify | default(false) | bool
     - target_os == 'fedora'
 
-- name: Ensure Spotify repository is configured (Fedora)
-  ansible.builtin.yum_repository:
-    name: "{{ spotify_repo_name }}"
-    description: "{{ spotify_repo_description }}"
-    baseurl: "{{ spotify_repo_baseurl }}"
-    enabled: true
-    gpgcheck: true
-    gpgkey: "{{ spotify_repo_gpgkey }}"
+- name: Ensure Spotify build groups exist (Fedora)
+  ansible.builtin.group:
+    name: "{{ item }}"
+    state: present
+    system: true
+  loop: "{{ spotify_lpf_groups }}"
   when:
     - install_spotify | default(false) | bool
     - target_os == 'fedora'
+
+- name: Ensure user is part of Spotify build groups (Fedora)
+  ansible.builtin.user:
+    name: "{{ username }}"
+    groups: "{{ item }}"
+    append: true
+  loop: "{{ spotify_lpf_groups }}"
+  when:
+    - install_spotify | default(false) | bool
+    - target_os == 'fedora'
+
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: auto
+  when: install_spotify | default(false) | bool
+
+- name: Build and install Spotify via LPF (Fedora)
+  ansible.builtin.command:
+    cmd: "{{ spotify_lpf_command }}"
+  become: true
+  become_user: "{{ username }}"
+  environment: "{{ spotify_lpf_environment }}"
+  when:
+    - install_spotify | default(false) | bool
+    - target_os == 'fedora'
+    - ansible_facts.packages is defined
+    - spotify_package_name not in ansible_facts.packages
 
 - name: Install Spotify via package manager
   ansible.builtin.package:
     name: "{{ spotify_package_name }}"
     state: present
     use: "{{ pkg_mgr }}"
-  when: install_spotify | default(false) | bool
+  when:
+    - install_spotify | default(false) | bool
+    - target_os != 'fedora'
 
 - name: Remove legacy Spotify Flatpak launcher
   ansible.builtin.file:

--- a/vars/arch.yml
+++ b/vars/arch.yml
@@ -197,10 +197,6 @@ flatpak_remote_name: flathub
 flatpak_remote_url: https://flathub.org/repo/flathub.flatpakrepo
 
 spotify_package_name: spotify-launcher
-spotify_repo_name: null
-spotify_repo_description: null
-spotify_repo_baseurl: null
-spotify_repo_gpgkey: null
 obsidian_package_name: obsidian
 obsidian_repo_name: null
 obsidian_repo_description: null

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -201,10 +201,13 @@ flatpak_remote_name: flathub
 flatpak_remote_url: https://flathub.org/repo/flathub.flatpakrepo
 
 spotify_package_name: spotify-client
-spotify_repo_name: spotify
-spotify_repo_description: Spotify (negativo17)
-spotify_repo_baseurl: "https://negativo17.org/repos/spotify/fedora-$releasever/$basearch/"
-spotify_repo_gpgkey: https://negativo17.org/repos/RPM-GPG-KEY-negativo17
+spotify_lpf_wrapper_package: lpf-spotify-client
+spotify_lpf_groups:
+  - pkg-build
+  - lpf
+spotify_lpf_command: lpf update
+spotify_lpf_environment:
+  LPF_ACCEPT_LICENSE: "1"
 obsidian_package_name: obsidian
 obsidian_repo_name: obsidian
 obsidian_repo_description: Obsidian


### PR DESCRIPTION
## Summary
- replace the negativo17 repository tasks with an RPM Fusion + LPF workflow for installing Spotify on Fedora
- ensure the target user joins the required LPF build groups and document the new flow
- drop unused Spotify repository variables from Fedora and Arch defaults

## Testing
- not run (ansible-lint not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6902e246c833285721ca2c60abd1b