### PR TITLE
Switch Obsidian installation to AppImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Presets enable the GUI applications you want via boolean flags. Set a flag to `t
 | Flag | Description |
 | --- | --- |
 | `install_spotify` | Install Spotify via native packages (RPM Fusion + LPF workflow on Fedora, community repo on Arch) and ensure the Flatpak wrapper is removed. |
-| `install_obsidian` | Install Obsidian from the official repositories (RPM on Fedora, community package on Arch) and remove the legacy Flatpak wrapper. |
+| `install_obsidian` | Download the Obsidian AppImage and expose it through `/usr/local/bin/obsidian`, replacing the legacy Flatpak wrapper. |
 | `install_chatgpt_desktop` | Download the ChatGPT Desktop AppImage and install a `/usr/local/bin/chatgpt-desktop` wrapper. |
 | `install_mattermost` | Install the Mattermost desktop client from Flathub and add a `/usr/local/bin/mattermost` launcher. |
 | `install_pgmodeler` | Install pgModeler from the native package repositories. |

--- a/docs/fresh-install.md
+++ b/docs/fresh-install.md
@@ -37,7 +37,7 @@ n be restored during provisioning.
 Each preset exposes boolean flags that control optional GUI software. Set any of these to `false` if you want to skip an app (or `true` to ensure it is installed):
 
 - `install_spotify` – installs Spotify via the native package repositories (RPM Fusion + LPF workflow on Fedora, community package on Arch) and removes the legacy Flatpak wrapper.
-- `install_obsidian` – installs Obsidian from the official repositories (RPM on Fedora, community package on Arch) and removes the legacy Flatpak wrapper.
+- `install_obsidian` – downloads the Obsidian AppImage and exposes it through `/usr/local/bin/obsidian`, replacing the legacy Flatpak wrapper.
 - `install_chatgpt_desktop` – downloads the ChatGPT Desktop AppImage and exposes it through `/usr/local/bin/chatgpt-desktop`.
 - `install_mattermost` – installs the Mattermost desktop client from Flathub and exposes it through `/usr/local/bin/mattermost`.
 - `install_pgmodeler` – installs pgModeler from the distro repositories.

--- a/tasks/gui-software.yml
+++ b/tasks/gui-software.yml
@@ -116,37 +116,29 @@
     state: absent
   when: install_spotify | default(false) | bool
 
-- name: Ensure Obsidian repository GPG key is installed (Fedora)
-  ansible.builtin.rpm_key:
-    key: "{{ obsidian_repo_gpgkey }}"
-    state: present
-  when:
-    - install_obsidian | default(false) | bool
-    - target_os == 'fedora'
-
-- name: Ensure Obsidian repository is configured (Fedora)
-  ansible.builtin.yum_repository:
-    name: "{{ obsidian_repo_name }}"
-    description: "{{ obsidian_repo_description }}"
-    baseurl: "{{ obsidian_repo_baseurl }}"
-    enabled: true
-    gpgcheck: true
-    gpgkey: "{{ obsidian_repo_gpgkey }}"
-  when:
-    - install_obsidian | default(false) | bool
-    - target_os == 'fedora'
-
-- name: Install Obsidian via package manager
-  ansible.builtin.package:
-    name: "{{ obsidian_package_name }}"
-    state: present
-    use: "{{ pkg_mgr }}"
+- name: Ensure Obsidian AppImage directory exists
+  ansible.builtin.file:
+    path: "{{ obsidian_appimage_dir }}"
+    state: directory
+    mode: '0755'
   when: install_obsidian | default(false) | bool
 
-- name: Remove legacy Obsidian Flatpak launcher
-  ansible.builtin.file:
-    path: /usr/local/bin/obsidian
-    state: absent
+- name: Download Obsidian AppImage
+  ansible.builtin.get_url:
+    url: "{{ obsidian_appimage_url }}"
+    dest: "{{ obsidian_appimage_path }}"
+    mode: '0755'
+  when: install_obsidian | default(false) | bool
+
+- name: Ensure obsidian launcher script is present
+  ansible.builtin.copy:
+    dest: /usr/local/bin/obsidian
+    mode: '0755'
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      exec "{{ obsidian_appimage_path }}" "$@"
   when: install_obsidian | default(false) | bool
 
 - name: Ensure ChatGPT Desktop directory exists

--- a/vars/arch.yml
+++ b/vars/arch.yml
@@ -197,11 +197,9 @@ flatpak_remote_name: flathub
 flatpak_remote_url: https://flathub.org/repo/flathub.flatpakrepo
 
 spotify_package_name: spotify-launcher
-obsidian_package_name: obsidian
-obsidian_repo_name: null
-obsidian_repo_description: null
-obsidian_repo_baseurl: null
-obsidian_repo_gpgkey: null
+obsidian_appimage_url: https://github.com/obsidianmd/obsidian-releases/releases/latest/download/Obsidian.AppImage
+obsidian_appimage_path: /opt/obsidian/Obsidian.AppImage
+obsidian_appimage_dir: /opt/obsidian
 chatgpt_desktop_appimage_url: https://github.com/lencx/ChatGPT/releases/latest/download/ChatGPT_amd64.AppImage
 chatgpt_desktop_appimage_path: /opt/chatgpt-desktop/ChatGPT.AppImage
 chatgpt_desktop_appimage_dir: /opt/chatgpt-desktop

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -208,11 +208,9 @@ spotify_lpf_groups:
 spotify_lpf_command: lpf update
 spotify_lpf_environment:
   LPF_ACCEPT_LICENSE: "1"
-obsidian_package_name: obsidian
-obsidian_repo_name: obsidian
-obsidian_repo_description: Obsidian
-obsidian_repo_baseurl: https://mirrors.obsidian.md/obsidian/rpm/$basearch
-obsidian_repo_gpgkey: https://mirrors.obsidian.md/obsidian/rpm/obsidian.gpg.key
+obsidian_appimage_url: https://github.com/obsidianmd/obsidian-releases/releases/latest/download/Obsidian.AppImage
+obsidian_appimage_path: /opt/obsidian/Obsidian.AppImage
+obsidian_appimage_dir: /opt/obsidian
 chatgpt_desktop_appimage_url: https://github.com/lencx/ChatGPT/releases/latest/download/ChatGPT_amd64.AppImage
 chatgpt_desktop_appimage_path: /opt/chatgpt-desktop/ChatGPT.AppImage
 chatgpt_desktop_appimage_dir: /opt/chatgpt-desktop


### PR DESCRIPTION
## Summary
- replace the RPM-based Obsidian installation with an AppImage workflow and launcher script
- update Fedora and Arch variables to reference the shared Obsidian AppImage download and install path
- document the new AppImage-based installation flow in the README and fresh install guide

## Testing
- `ansible-playbook --syntax-check main.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e696088238833285d0a6fc16117f03